### PR TITLE
Minor optimizations for GlGh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/pthash"]
 	path = lib/pthash
 	url = https://github.com/jermp/pthash.git
+[submodule "lib/fastmod"]
+	path = lib/fastmod
+	url = https://github.com/lemire/fastmod

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,9 @@ set_target_properties(test-mphf-quotient PROPERTIES CXX_STANDARD 17 CXX_STANDARD
 add_cltj_executable(test-mphf-adversarial src/test/hashing/test_mphf_adversarial.cpp test)
 set_target_properties(test-mphf-adversarial PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-mphf-serialization src/test/hashing/test_mphf_serialization.cpp test)
+set_target_properties(test-mphf-serialization PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(test-pthash-simple src/test/hashing/test_pthash_simple.cpp test)
 target_link_libraries(test-pthash-simple PRIVATE PTHASH)
 set_target_properties(test-pthash-simple PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -127,7 +127,9 @@ class MPHF {
         breakdown.used_pos_bytes = storage_breakdown.used_pos_bytes;
         breakdown.rank_bytes = storage_breakdown.rank_bytes;
         breakdown.q_bytes = key_policy_.size_in_bytes();
-        breakdown.other_bytes = sizeof(m_) + sizeof(n_) + sizeof(primes_) + sizeof(retry_count_);
+        // Metadata: n (4) + 3×prime_deltas (3) + retry_count (1) = 8 bytes
+        // Note: m_ and primes_ are not serialized (computed/reconstructed)
+        breakdown.other_bytes = sizeof(n_) + 3 * sizeof(uint8_t) + sizeof(retry_count_);
         return breakdown;
     }
 
@@ -157,11 +159,17 @@ class MPHF {
 
         // Core data structures (essential for queries)
         written_bytes += storage_.serialize(out, child, "storage_");
-        written_bytes += sdsl::write_member(m_, out, child, "m_");
         written_bytes += sdsl::write_member(n_, out, child, "n_");
 
         // Hash function parameters (essential for queries)
-        written_bytes += sdsl::write_member(primes_, out, child, "primes_");
+        // Store p_j as delta_j = p_j - target_segment
+        const uint64_t target_segment = compute_target_segment();
+        for (int k = 0; k < 3; ++k) {
+            uint64_t delta = primes_[k] - target_segment;
+            assert(delta <= 255 && "Prime delta out of uint8_t range - unexpected!");
+            uint8_t delta_byte = static_cast<uint8_t>(delta);
+            written_bytes += sdsl::write_member(delta_byte, out, child, "prime_delta_" + std::to_string(k));
+        }
         written_bytes += sdsl::write_member(retry_count_, out, child, "retry_count_");
 
         // Key policy payload (e.g., QuotientKey or FullKey data)
@@ -178,12 +186,19 @@ class MPHF {
     void load(std::istream& in) {
         // Core data structures
         storage_.load(in);
-        sdsl::read_member(m_, in);
         sdsl::read_member(n_, in);
 
         // Hash function parameters
-        sdsl::read_member(primes_, in);
+        // Reconstruct primes from delta_j = p_j - target_segment
+        const uint64_t target_segment = compute_target_segment();
+        for (int k = 0; k < 3; ++k) {
+            uint8_t delta;
+            sdsl::read_member(delta, in);
+            primes_[k] = target_segment + delta;
+        }
         sdsl::read_member(retry_count_, in);
+
+        m_ = static_cast<uint32_t>(primes_[0] + primes_[1] + primes_[2]);
 
         // Recompute segment_starts from primes
         segment_starts_[0] = 0;
@@ -302,6 +317,15 @@ class MPHF {
     }
 
   private:
+    /**
+     * @brief Compute target segment size for prime selection
+     * @return The target segment size (~m/3) used as base for prime selection
+     */
+    uint64_t compute_target_segment() const {
+        const uint64_t target_m = static_cast<uint64_t>(std::ceil(1.25 * static_cast<double>(n_)));
+        return std::max<uint64_t>(3, (target_m + 2) / 3);  // ceil(target_m/3)
+    }
+
     // ========== STEP 1: Hash Function Initialization ==========
     /**
      * @brief Initialize the three hash functions h0, h1, h2
@@ -310,8 +334,7 @@ class MPHF {
      * to vary the hypergraph while keeping m essentially constant.
      */
     bool initialize_hash_functions(const std::vector<uint64_t>& keys, int retry_count) {
-        const uint64_t target_m = static_cast<uint64_t>(std::ceil(1.25 * static_cast<double>(n_)));
-        const uint64_t target_segment = std::max<uint64_t>(3, (target_m + 2) / 3);  // ceil(target_m/3)
+        const uint64_t target_segment = compute_target_segment();
 
         if (retry_count == 0) {
             uint64_t base = target_segment;

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -127,8 +127,7 @@ class MPHF {
         breakdown.used_pos_bytes = storage_breakdown.used_pos_bytes;
         breakdown.rank_bytes = storage_breakdown.rank_bytes;
         breakdown.q_bytes = key_policy_.size_in_bytes();
-        breakdown.other_bytes =
-            sizeof(m_) + sizeof(n_) + sizeof(primes_) + sizeof(segment_starts_) + sizeof(retry_count_);
+        breakdown.other_bytes = sizeof(m_) + sizeof(n_) + sizeof(primes_) + sizeof(retry_count_);
         return breakdown;
     }
 
@@ -163,7 +162,6 @@ class MPHF {
 
         // Hash function parameters (essential for queries)
         written_bytes += sdsl::write_member(primes_, out, child, "primes_");
-        written_bytes += sdsl::write_member(segment_starts_, out, child, "segment_starts_");
         written_bytes += sdsl::write_member(retry_count_, out, child, "retry_count_");
 
         // Key policy payload (e.g., QuotientKey or FullKey data)
@@ -185,8 +183,12 @@ class MPHF {
 
         // Hash function parameters
         sdsl::read_member(primes_, in);
-        sdsl::read_member(segment_starts_, in);
         sdsl::read_member(retry_count_, in);
+
+        // Recompute segment_starts from primes
+        segment_starts_[0] = 0;
+        segment_starts_[1] = primes_[0];
+        segment_starts_[2] = primes_[0] + primes_[1];
 
         regenerate_coefficients();
 

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -67,7 +67,7 @@ class MPHF {
     // For retry logic
     static constexpr int MAX_RETRIES = 10;
     static constexpr uint64_t SEED = 0xC1A0ULL;
-    int retry_count_;  // Number of retries used in last build
+    uint8_t retry_count_;  // Number of retries used in last build (stored for serialization)
 
   public:
     using size_type = size_t;  // Required for sdsl::size_in_bytes
@@ -127,8 +127,8 @@ class MPHF {
         breakdown.used_pos_bytes = storage_breakdown.used_pos_bytes;
         breakdown.rank_bytes = storage_breakdown.rank_bytes;
         breakdown.q_bytes = key_policy_.size_in_bytes();
-        breakdown.other_bytes = sizeof(m_) + sizeof(n_) + sizeof(primes_) + sizeof(multipliers_) +
-            sizeof(biases_) + sizeof(segment_starts_);
+        breakdown.other_bytes =
+            sizeof(m_) + sizeof(n_) + sizeof(primes_) + sizeof(segment_starts_) + sizeof(retry_count_);
         return breakdown;
     }
 
@@ -163,14 +163,11 @@ class MPHF {
 
         // Hash function parameters (essential for queries)
         written_bytes += sdsl::write_member(primes_, out, child, "primes_");
-        written_bytes += sdsl::write_member(multipliers_, out, child, "multipliers_");
-        written_bytes += sdsl::write_member(biases_, out, child, "biases_");
         written_bytes += sdsl::write_member(segment_starts_, out, child, "segment_starts_");
+        written_bytes += sdsl::write_member(retry_count_, out, child, "retry_count_");
 
         // Key policy payload (e.g., QuotientKey or FullKey data)
         written_bytes += key_policy_.serialize(out, child, "key_policy_");
-
-        // Note: retry_count_ is NOT serialized as it's only needed during construction
 
         sdsl::structure_tree::add_size(child, written_bytes);
         return written_bytes;
@@ -188,18 +185,16 @@ class MPHF {
 
         // Hash function parameters
         sdsl::read_member(primes_, in);
-        sdsl::read_member(multipliers_, in);
-        sdsl::read_member(biases_, in);
         sdsl::read_member(segment_starts_, in);
+        sdsl::read_member(retry_count_, in);
+
+        regenerate_coefficients();
 
         // Rebind context for key policy and load its payload (if any).
         // Note: max_key is not needed in load() since init() is not called, only bind_context().
         policies::KeyInitContext ctx{n_, primes_, multipliers_, biases_, segment_starts_, 0};
         key_policy_.bind_context(ctx);
         key_policy_.load(in);
-
-        // Reset retry_count since it's not serialized
-        retry_count_ = 0;
     }
 
     /**
@@ -336,8 +331,9 @@ class MPHF {
         segment_starts_[2] = primes_[0] + primes_[1];
         m_ = static_cast<uint32_t>(primes_[0] + primes_[1] + primes_[2]);
 
-        // Deterministic RNG for multipliers with retry_count offset
-        std::mt19937_64 rng(SEED + static_cast<uint64_t>(retry_count));
+        // Use SplitMix64 mixer for better seed diversity
+        uint64_t final_seed = splitmix64(SEED ^ static_cast<uint64_t>(retry_count));
+        std::mt19937_64 rng(final_seed);
         for (int k = 0; k < 3; ++k) {
             uint64_t p = primes_[static_cast<size_t>(k)];
             std::uniform_int_distribution<uint64_t> distA(1, p - 1);
@@ -514,6 +510,25 @@ class MPHF {
     }
 
     // ========== HELPER FUNCTIONS ==========
+    /**
+     * @brief Regenerate multipliers and biases from retry_count using SplitMix64 mixer.
+     * Used during deserialization to avoid storing 48 bytes of coefficients.
+     */
+    void regenerate_coefficients() {
+        uint64_t final_seed = splitmix64(SEED ^ static_cast<uint64_t>(retry_count_));
+        std::mt19937_64 rng(final_seed);
+        for (int k = 0; k < 3; ++k) {
+            uint64_t p = primes_[static_cast<size_t>(k)];
+            std::uniform_int_distribution<uint64_t> distA(1, p - 1);
+            multipliers_[static_cast<size_t>(k)] = distA(rng);
+        }
+        for (int k = 0; k < 3; ++k) {
+            uint64_t p = primes_[static_cast<size_t>(k)];
+            std::uniform_int_distribution<uint64_t> distB(0, p - 1);
+            biases_[static_cast<size_t>(k)] = distB(rng);
+        }
+    }
+
     /**
      * @brief Compute hash function h_k(x) for k ∈ {0,1,2}
      * h_k(x) = d_k + ((a_k · x + b_k) mod r_k)

--- a/include/hashing/mphf_utils.hpp
+++ b/include/hashing/mphf_utils.hpp
@@ -129,5 +129,21 @@ inline uint64_t mod_inverse(uint64_t a, uint64_t p) {
     return mod_pow(a, p - 2, p);
 }
 
+/**
+ * @brief SplitMix64 hash mixer for seed diversification.
+ *
+ * Ensures that numerically close seeds produce completely different outputs
+ * when initializing PRNGs.
+ *
+ * Written in 2015 by Sebastiano Vigna (vigna@acm.org), public domain.
+ * Reference: https://github.com/svaarala/duktape/blob/master/misc/splitmix64.c
+ */
+inline uint64_t splitmix64(uint64_t x) {
+    x += 0x9E3779B97F4A7C15ULL;
+    x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    x = (x ^ (x >> 27)) * 0x94D049BB133111EBULL;
+    return x ^ (x >> 31);
+}
+
 }  // namespace hashing
 }  // namespace cltj

--- a/include/hashing/storage/packed_trit.hpp
+++ b/include/hashing/storage/packed_trit.hpp
@@ -162,6 +162,7 @@ class PackedTritStorage : public StorageStrategy<PackedTritStorage<BStrategy>> {
         B_.load(in);
         sdsl::read_member(m_, in);
         sdsl::read_member(n_, in);
+        construction_complete_ = true;
     }
 
     size_t size_in_bytes() const { return G_prime_.size_in_bytes() + B_.size_in_bytes(); }

--- a/src/test/hashing/test_mphf_serialization.cpp
+++ b/src/test/hashing/test_mphf_serialization.cpp
@@ -1,0 +1,194 @@
+// Test suite for MPHF serialization round-trip correctness
+// Verifies that serialize() → load() preserves all internal state and query results
+// NOTE: Currently only tests GlGhStorage because BaselineStorage and PackedTritStorage have double-free bugs in destructors (detected by ASan - issue with SDSL memory management)
+// TODO: Fix above issue and re-enable BaselineStorage and PackedTritStorage tests
+#include <hashing/mphf_bdz.hpp>
+#include <hashing/storage/packed_trit.hpp>
+#include <hashing/storage/glgh.hpp>
+#include <util/logger.hpp>
+#include <cassert>
+#include <sstream>
+#include <random>
+#include <unordered_set>
+#include <vector>
+#include <iostream>
+
+using cltj::hashing::GlGhStorage;
+using cltj::hashing::MPHF;
+using cltj::hashing::policies::FullKey;
+
+// Helper to generate unique random keys
+static std::vector<uint64_t> generate_keys(size_t n, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::unordered_set<uint64_t> unique_keys;
+    std::uniform_int_distribution<uint64_t> dist(1, n * 100);
+    while (unique_keys.size() < n) {
+        unique_keys.insert(dist(rng));
+    }
+    return std::vector<uint64_t>(unique_keys.begin(), unique_keys.end());
+}
+
+/**
+ * @brief Test serialization round-trip for a given storage strategy
+ * 
+ * Verifies that after serialize() -> load():
+ * 1. All metadata fields match (m, n, retry_count)
+ * 2. All query() results are identical
+ * 3. contains() behaves identically
+ * 4. Size breakdown is preserved
+ */
+template <typename StorageStrategy>
+void test_roundtrip(size_t n, const std::string& strategy_name) {
+    std::cout << "\n--- Round-Trip Test: n=" << n << " [" << strategy_name << "] ---" << std::endl;
+
+    auto keys = generate_keys(n, 42 + n);
+
+    // Build original MPHF
+    MPHF<StorageStrategy, FullKey> mphf1;
+    bool build_ok = mphf1.build(keys);
+    if (!build_ok) {
+        throw std::runtime_error("Build failed");
+    }
+    std::cout << "  [OK] Built original MPHF" << std::endl;
+
+    // Capture original state
+    uint32_t original_m = mphf1.m();
+    uint32_t original_n = mphf1.n();
+    int original_retries = mphf1.retry_count();
+    auto original_breakdown = mphf1.get_size_breakdown();
+
+    // Serialize to stringstream
+    std::stringstream ss;
+    size_t written = mphf1.serialize(ss, nullptr, "mphf_test");
+    std::cout << "  [OK] Serialized " << written << " bytes" << std::endl;
+
+    // Reset stream position to beginning for reading
+    ss.seekg(0, std::ios::beg);
+
+    // Deserialize into new MPHF
+    MPHF<StorageStrategy, FullKey> mphf2;
+    mphf2.load(ss);
+    std::cout << "  [OK] Deserialized from stream" << std::endl;
+
+    // ===== VERIFICATION =====
+
+    // 1. Check metadata fields
+    assert(mphf2.m() == original_m && "m_ mismatch after load");
+    assert(mphf2.n() == original_n && "n_ mismatch after load");
+    assert(mphf2.retry_count() == original_retries && "retry_count_ mismatch after load");
+    std::cout << "  [OK] Metadata preserved: m=" << original_m << " n=" << original_n
+              << " retries=" << original_retries << std::endl;
+
+    // 2. Check that all query() results match
+    bool queries_match = true;
+    for (const auto& key : keys) {
+        uint32_t h1 = mphf1.query(key);
+        uint32_t h2 = mphf2.query(key);
+        if (h1 != h2) {
+            std::cerr << "ERROR: query(" << key << ") differs: " << h1 << " vs " << h2 << std::endl;
+            queries_match = false;
+        }
+    }
+    assert(queries_match && "Queries differ after deserialization");
+    std::cout << "  [OK] All " << keys.size() << " query() results match" << std::endl;
+
+    // 3. Check that contains() behaves identically for true positives
+    bool contains_match = true;
+    for (const auto& key : keys) {
+        bool c1 = mphf1.contains(key);
+        bool c2 = mphf2.contains(key);
+        if (c1 != c2) {
+            std::cerr << "ERROR: contains(" << key << ") differs: " << c1 << " vs " << c2 << std::endl;
+            contains_match = false;
+        }
+    }
+    assert(contains_match && "contains() differs after deserialization");
+    std::cout << "  [OK] All contains() results match" << std::endl;
+
+    // 4. Check false positives match (sample a few non-keys)
+    std::mt19937_64 rng(12345);
+    std::unordered_set<uint64_t> key_set(keys.begin(), keys.end());
+    size_t fp_sample = std::min((size_t)1000, n / 10);
+    bool fp_match = true;
+    for (size_t i = 0; i < fp_sample; ++i) {
+        uint64_t non_key;
+        do {
+            non_key = rng();
+        } while (key_set.count(non_key));
+
+        bool c1 = mphf1.contains(non_key);
+        bool c2 = mphf2.contains(non_key);
+        if (c1 != c2) {
+            std::cerr << "ERROR: contains(" << non_key << ") differs for non-key: " << c1 << " vs " << c2
+                      << std::endl;
+            fp_match = false;
+        }
+    }
+    assert(fp_match && "False positive behavior differs after deserialization");
+    std::cout << "  [OK] False positive behavior matches (sampled " << fp_sample << " non-keys)" << std::endl;
+
+    // 5. Check that size breakdown is identical
+    auto new_breakdown = mphf2.get_size_breakdown();
+    assert(
+        new_breakdown.total_bytes() == original_breakdown.total_bytes() &&
+        "Size breakdown differs after deserialization"
+    );
+    assert(new_breakdown.g_bytes == original_breakdown.g_bytes && "G bytes differ");
+    assert(new_breakdown.used_pos_bytes == original_breakdown.used_pos_bytes && "Used pos bytes differ");
+    assert(new_breakdown.rank_bytes == original_breakdown.rank_bytes && "Rank bytes differ");
+    assert(new_breakdown.q_bytes == original_breakdown.q_bytes && "Q bytes differ");
+    assert(new_breakdown.other_bytes == original_breakdown.other_bytes && "Other bytes differ");
+    std::cout << "  [OK] Size breakdown matches: " << new_breakdown.total_bytes() << " bytes" << std::endl;
+
+    std::cout << "  PASSED: All fields and queries preserved after round-trip" << std::endl;
+}
+
+int main() {
+    std::cout << "========== MPHF Serialization Round-Trip Tests ==========" << std::endl;
+    std::cout << "Verifying that serialize() -> load() preserves all internal state" << std::endl;
+
+    std::vector<size_t> test_sizes = {100, 1000, 10000, 100000};
+    int total_tests = 0;
+    int passed = 0;
+
+    for (size_t n : test_sizes) {
+        try {
+            // Test GlGhStorage (the optimized one with seed-based serialization)
+            test_roundtrip<GlGhStorage>(n, "GlGhStorage");
+            passed++;
+        } catch (const std::exception& e) {
+            std::cerr << "FAILED: GlGhStorage n=" << n << " - " << e.what() << std::endl;
+        }
+        total_tests++;
+
+        // try {
+        //     test_roundtrip<BaselineStorage>(n, "BaselineStorage");
+        //     passed++;
+        // } catch (const std::exception& e) {
+        //     std::cerr << "FAILED: BaselineStorage n=" << n << " - " << e.what() << std::endl;
+        // }
+        // total_tests++;
+        //
+        // try {
+        //     test_roundtrip<PackedTritStorage<CompressedBitvector>>(n, "PackedTritStorage");
+        //     passed++;
+        // } catch (const std::exception& e) {
+        //     std::cerr << "FAILED: PackedTritStorage n=" << n << " - " << e.what() << std::endl;
+        // }
+        // total_tests++;
+    }
+
+    std::cout << "\n========== Test Summary ==========" << std::endl;
+    std::cout << "Total: " << total_tests << " (" << test_sizes.size() << " size × GlGhStorage only)"
+              << std::endl;
+    std::cout << "Passed: " << passed << "/" << total_tests << std::endl;
+    std::cout << "Failed: " << (total_tests - passed) << "/" << total_tests << std::endl;
+
+    if (passed == total_tests) {
+        std::cout << "ALL SERIALIZATION TESTS PASSED" << std::endl;
+        return 0;
+    } else {
+        std::cout << "SOME SERIALIZATION TESTS FAILED" << std::endl;
+        return 1;
+    }
+}

--- a/src/test/hashing/test_mphf_utils.cpp
+++ b/src/test/hashing/test_mphf_utils.cpp
@@ -120,6 +120,41 @@ void test_mod_inverse() {
     LOG_INFO("mod_inverse tests passed!");
 }
 
+void test_splitmix64() {
+    LOG_INFO("Testing splitmix64...");
+
+    // Test that consecutive seeds produce very different outputs
+    uint64_t out0 = splitmix64(0);
+    uint64_t out1 = splitmix64(1);
+    uint64_t out2 = splitmix64(2);
+
+    assert(out0 != out1);
+    assert(out1 != out2);
+    assert(out0 != out2);
+
+    // Test determinism: same input produces same output
+    assert(splitmix64(42) == splitmix64(42));
+    assert(splitmix64(1000) == splitmix64(1000));
+
+    // Test that mixing provides good avalanche (1-bit difference in input should change ~50% of output bits)
+    uint64_t a = splitmix64(0x1234567890ABCDEFULL);
+    uint64_t b = splitmix64(0x1234567890ABCDEFULL ^ 1ULL);  // flip 1 bit
+    int changed_bits = __builtin_popcountll(a ^ b);
+    assert(changed_bits > 20 && changed_bits < 44);  // expect ~32 bits changed (50%)
+
+    // Test with SEED + retry_count pattern (as used in MPHF)
+    const uint64_t SEED = 0xC1A0ULL;
+    uint64_t mixed0 = splitmix64(SEED ^ 0);
+    uint64_t mixed1 = splitmix64(SEED ^ 1);
+    uint64_t mixed10 = splitmix64(SEED ^ 10);
+
+    assert(mixed0 != mixed1);
+    assert(mixed1 != mixed10);
+    assert(mixed0 != mixed10);
+
+    LOG_INFO("splitmix64 tests passed!");
+}
+
 int main() {
     test_mod_mul();
     test_mod_pow();
@@ -127,6 +162,7 @@ int main() {
     test_next_prime();
     test_all_coprime();
     test_mod_inverse();
+    test_splitmix64();
 
     LOG_INFO("All mphf_utils tests passed successfully!");
     return 0;


### PR DESCRIPTION
## MPHF Serialization Optimizations

Reduces metadata size from 104 to 8 bytes (92% reduction) by eliminating redundant fields from serialization.

### Changes

**1. Seed-based coefficient regeneration**
- Store `retry_count` (1 byte) instead of `multipliers[3]` + `biases[3]` (48 bytes)
- Added `splitmix64()` mixer for better seed diversity across retries
- Coefficients regenerated deterministically in `load()` using `retry_count`

**2. Delta-compressed primes**
- Store primes as `delta_k = prime_k - target_segment` (3 bytes) instead of full values (24 bytes)
- `m_` removed from serialization (recomputed as `sum(primes)`)
- `segment_starts_` removed (recomputed from primes)

**3. Round-trip test**
- New test `test-mphf-serialization` verifies serialize/load preserves all state
- Tests GlGhStorage on sizes: 100, 1K, 10K, 100K
- Validates: metadata, query results, contains behavior, size breakdown

### Notes

- [Fastmod submodule](https://github.com/lemire/fastmod) added but not integrated (ran benchmark on MacOS (ARM) and it was slower compared to native module)
- Fixed `PackedTritStorage::load()` missing `construction_complete_ = true`

### Test Results

All correctness tests pass (test-mphf, test-mphf-quotient, test-mphf-adversarial, test-mphf-serialization).