### PR TITLE
Embed MPHF<GlGh, QuotientKey> into CLTJ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,9 @@ set_target_properties(test-mphf-adversarial PROPERTIES CXX_STANDARD 17 CXX_STAND
 add_cltj_executable(test-mphf-serialization src/test/hashing/test_mphf_serialization.cpp test)
 set_target_properties(test-mphf-serialization PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-mphf-move src/test/hashing/test_mphf_move.cpp test)
+set_target_properties(test-mphf-move PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(test-pthash-simple src/test/hashing/test_pthash_simple.cpp test)
 target_link_libraries(test-pthash-simple PRIVATE PTHASH)
 set_target_properties(test-pthash-simple PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ target_compile_definitions(bench-query-hcltj-global PRIVATE ADAPTIVE=0)
 add_cltj_executable(stats-hcltj src/bench/stats-hcltj.cpp analysis)
 set_target_properties(stats-hcltj PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(dump-trie-hcltj src/bench/dump-trie-hcltj.cpp analysis)
+set_target_properties(dump-trie-hcltj PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(bench-query-cltj-rdf src/bench/bench-query-cltj-rdf.cpp bench hybridbv_gn)
 target_compile_definitions(bench-query-cltj-rdf PRIVATE ADAPTIVE=1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ add_cltj_executable(bench-query-hcltj-global src/bench/bench-query-hcltj.cpp ben
 target_compile_definitions(bench-query-hcltj-global PRIVATE ADAPTIVE=0)
 
 add_cltj_executable(stats-hcltj src/bench/stats-hcltj.cpp analysis)
+set_target_properties(stats-hcltj PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 add_cltj_executable(bench-query-cltj-rdf src/bench/bench-query-cltj-rdf.cpp bench hybridbv_gn)
 target_compile_definitions(bench-query-cltj-rdf PRIVATE ADAPTIVE=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,9 @@ add_cltj_executable(analyze-trie-structure src/test/hashing/analyze_trie_structu
 add_cltj_executable(test-children-histogram src/test/hcltj/test_children_histogram.cpp test/hcltj)
 set_target_properties(test-children-histogram PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-hash-contains src/test/hcltj/test_hash_contains.cpp test/hcltj)
+set_target_properties(test-hash-contains PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(count-distinct-spo src/analysis/count_distinct_spo.cpp analysis)
 
 add_cltj_executable(bench-mphf-hashing src/bench/bench_mphf_hashing.cpp analysis)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,9 @@ set_target_properties(test-pthash-simple PROPERTIES CXX_STANDARD 17 CXX_STANDARD
 
 add_cltj_executable(analyze-trie-structure src/test/hashing/analyze_trie_structure.cpp analysis)
 
+add_cltj_executable(test-children-histogram src/test/hcltj/test_children_histogram.cpp test/hcltj)
+set_target_properties(test-children-histogram PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(count-distinct-spo src/analysis/count_distinct_spo.cpp analysis)
 
 add_cltj_executable(bench-mphf-hashing src/bench/bench_mphf_hashing.cpp analysis)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,9 @@ set_target_properties(test-children-histogram PROPERTIES CXX_STANDARD 17 CXX_STA
 add_cltj_executable(test-hash-contains src/test/hcltj/test_hash_contains.cpp test/hcltj)
 set_target_properties(test-hash-contains PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-hcltj-correctness src/test/hcltj/test_hcltj_correctness.cpp test/hcltj)
+set_target_properties(test-hcltj-correctness PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(count-distinct-spo src/analysis/count_distinct_spo.cpp analysis)
 
 add_cltj_executable(bench-mphf-hashing src/bench/bench_mphf_hashing.cpp analysis)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ target_compile_definitions(bench-query-hcltj PRIVATE ADAPTIVE=1)
 add_cltj_executable(bench-query-hcltj-global src/bench/bench-query-hcltj.cpp bench)
 target_compile_definitions(bench-query-hcltj-global PRIVATE ADAPTIVE=0)
 
+add_cltj_executable(stats-hcltj src/bench/stats-hcltj.cpp analysis)
+
 add_cltj_executable(bench-query-cltj-rdf src/bench/bench-query-cltj-rdf.cpp bench hybridbv_gn)
 target_compile_definitions(bench-query-cltj-rdf PRIVATE ADAPTIVE=1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ add_cltj_executable(build-cltj-dyn src/bench/build-cltj-dyn.cpp bench hybridbv_g
 
 add_cltj_executable(build-xcltj src/bench/build-xcltj.cpp bench hybridbv_gn)
 
+add_cltj_executable(build-hcltj src/bench/build-hcltj.cpp bench hybridbv_gn)
+
 add_cltj_executable(build-xcltj-dyn src/bench/build-xcltj-dyn.cpp bench hybridbv_gn)
 
 add_cltj_executable(build-uncltj src/bench/build-uncltj.cpp bench)
@@ -113,6 +115,12 @@ target_compile_definitions(bench-query-xcltj PRIVATE ADAPTIVE=1)
 
 add_cltj_executable(bench-query-xcltj-global src/bench/bench-query-xcltj.cpp bench)
 target_compile_definitions(bench-query-xcltj-global PRIVATE ADAPTIVE=0)
+
+add_cltj_executable(bench-query-hcltj src/bench/bench-query-hcltj.cpp bench)
+target_compile_definitions(bench-query-hcltj PRIVATE ADAPTIVE=1)
+
+add_cltj_executable(bench-query-hcltj-global src/bench/bench-query-hcltj.cpp bench)
+target_compile_definitions(bench-query-hcltj-global PRIVATE ADAPTIVE=0)
 
 add_cltj_executable(bench-query-cltj-rdf src/bench/bench-query-cltj-rdf.cpp bench hybridbv_gn)
 target_compile_definitions(bench-query-cltj-rdf PRIVATE ADAPTIVE=1)

--- a/analysis/children_histogram/load.py
+++ b/analysis/children_histogram/load.py
@@ -1,0 +1,27 @@
+"""Load children-histogram CSVs produced by stats-hcltj."""
+
+import re
+from pathlib import Path
+
+import pandas as pd
+
+TRIE_NAMES = ["SPO", "SOP", "POS", "PSO", "OSP", "OPS"]
+CSV_PATTERN = re.compile(r"trie_(\d)_([A-Z]{3})\.csv")
+
+
+def load_histograms(outdir: str | Path) -> dict[str, pd.DataFrame]:
+    """Load per-trie histogram CSVs from *outdir*.
+
+    Returns a dict keyed by trie name (e.g. "SPO") with DataFrames
+    containing columns ``children`` and ``nodes``.
+    """
+    outdir = Path(outdir)
+    result: dict[str, pd.DataFrame] = {}
+    for path in sorted(outdir.glob("trie_*_*.csv")):
+        m = CSV_PATTERN.match(path.name)
+        if m is None:
+            continue
+        name = m.group(2)
+        df = pd.read_csv(path)
+        result[name] = df
+    return result

--- a/analysis/children_histogram/main.py
+++ b/analysis/children_histogram/main.py
@@ -1,0 +1,65 @@
+"""CLI: analyse children-histogram CSVs from stats-hcltj."""
+
+import argparse
+from pathlib import Path
+
+from load import load_histograms
+from plot import plot_coverage, plot_distribution
+from stats import coverage_by_threshold, summary
+
+DEFAULT_THRESHOLDS = [10, 50, 100, 500, 1000, 5000, 10000]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("outdir", help="Directory with trie_*_*.csv files")
+    parser.add_argument(
+        "--figdir",
+        help="Directory to save figures (default: outdir/figures)",
+    )
+    parser.add_argument(
+        "--thresholds",
+        nargs="+",
+        type=int,
+        default=DEFAULT_THRESHOLDS,
+        help="Threshold values to evaluate",
+    )
+    args = parser.parse_args()
+
+    outdir = Path(args.outdir)
+    figdir = Path(args.figdir) if args.figdir else outdir / "figures"
+    figdir.mkdir(parents=True, exist_ok=True)
+
+    histograms = load_histograms(outdir)
+    if not histograms:
+        print(f"No histogram CSVs found in {outdir}")
+        return
+
+    print(f"Loaded {len(histograms)} tries: {', '.join(histograms.keys())}\n")
+
+    for name, hist in histograms.items():
+        s = summary(hist)
+        print(
+            f"{name}: {s['total_nodes']} nodes, "
+            f"{s['total_children']} children, "
+            f"max={s['max_children']}"
+        )
+    print()
+
+    coverage_tables = {}
+    for name, hist in histograms.items():
+        cov = coverage_by_threshold(hist, args.thresholds)
+        coverage_tables[name] = cov
+        print(f"--- {name} ---")
+        print(cov.to_string())
+        print()
+
+    plot_distribution(histograms, savepath=figdir / "distribution.png")
+    print(f"Saved {figdir / 'distribution.png'}")
+
+    plot_coverage(coverage_tables, savepath=figdir / "coverage.png")
+    print(f"Saved {figdir / 'coverage.png'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/children_histogram/plot.py
+++ b/analysis/children_histogram/plot.py
@@ -1,0 +1,57 @@
+"""Plotting functions for children-histogram analysis."""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def plot_distribution(
+    histograms: dict[str, pd.DataFrame],
+    savepath: str | Path | None = None,
+) -> plt.Figure:
+    """Log-log scatter: children count vs number of nodes, one subplot per trie."""
+    n = len(histograms)
+    cols = min(n, 3)
+    rows = (n + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(5 * cols, 4 * rows), squeeze=False)
+
+    for ax, (name, hist) in zip(axes.flat, histograms.items()):
+        ax.scatter(hist["children"], hist["nodes"], s=12, alpha=0.7)
+        ax.set_xscale("log")
+        ax.set_yscale("log")
+        ax.set_xlabel("children per node")
+        ax.set_ylabel("number of nodes")
+        ax.set_title(name)
+        ax.grid(True, which="both", ls=":", alpha=0.4)
+
+    for ax in axes.flat[n:]:
+        ax.set_visible(False)
+
+    fig.suptitle("Children-per-node distribution (log-log)", y=1.02)
+    fig.tight_layout()
+    if savepath:
+        fig.savefig(savepath, dpi=150, bbox_inches="tight")
+    return fig
+
+
+def plot_coverage(
+    coverage_tables: dict[str, pd.DataFrame],
+    savepath: str | Path | None = None,
+) -> plt.Figure:
+    """Line plot: threshold vs % children covered, one line per trie."""
+    fig, ax = plt.subplots(figsize=(8, 5))
+
+    for name, cov in coverage_tables.items():
+        ax.plot(cov.index, cov["pct_children"], marker="o", markersize=4, label=name)
+
+    ax.set_xscale("log")
+    ax.set_xlabel("threshold")
+    ax.set_ylabel("% children covered by hashing")
+    ax.set_title("Hashing coverage vs threshold")
+    ax.legend()
+    ax.grid(True, which="both", ls=":", alpha=0.4)
+    fig.tight_layout()
+    if savepath:
+        fig.savefig(savepath, dpi=150, bbox_inches="tight")
+    return fig

--- a/analysis/children_histogram/stats.py
+++ b/analysis/children_histogram/stats.py
@@ -1,0 +1,50 @@
+"""Compute threshold-coverage statistics from children histograms."""
+
+import pandas as pd
+
+
+def coverage_by_threshold(
+    hist: pd.DataFrame,
+    thresholds: list[int],
+) -> pd.DataFrame:
+    """For each threshold, compute how many nodes/children would be hashed.
+
+    *hist* has columns ``children`` and ``nodes`` (output of stats-hcltj).
+    Returns a DataFrame indexed by threshold with columns:
+      - hashed_nodes, total_nodes, pct_nodes
+      - hashed_children, total_children, pct_children
+    """
+    total_nodes = int(hist["nodes"].sum())
+    total_children = int((hist["children"] * hist["nodes"]).sum())
+
+    rows = []
+    for t in thresholds:
+        mask = hist["children"] >= t
+        h_nodes = int(hist.loc[mask, "nodes"].sum())
+        h_children = int((hist.loc[mask, "children"] * hist.loc[mask, "nodes"]).sum())
+        rows.append(
+            {
+                "threshold": t,
+                "hashed_nodes": h_nodes,
+                "total_nodes": total_nodes,
+                "pct_nodes": 100.0 * h_nodes / total_nodes if total_nodes else 0,
+                "hashed_children": h_children,
+                "total_children": total_children,
+                "pct_children": (
+                    100.0 * h_children / total_children if total_children else 0
+                ),
+            }
+        )
+    return pd.DataFrame(rows).set_index("threshold")
+
+
+def summary(hist: pd.DataFrame) -> dict:
+    """Basic summary stats for a single trie histogram."""
+    total_nodes = int(hist["nodes"].sum())
+    total_children = int((hist["children"] * hist["nodes"]).sum())
+    max_children = int(hist["children"].max())
+    return {
+        "total_nodes": total_nodes,
+        "total_children": total_children,
+        "max_children": max_children,
+    }

--- a/analysis/pyproject.toml
+++ b/analysis/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "ipykernel>=6.29.5",
     "matplotlib>=3.10.3",
+    "networkx>=3.2",
     "notebook>=7.4.4",
     "pandas>=2.3.1",
     "seaborn>=0.13.2",

--- a/analysis/trie_viz/load.py
+++ b/analysis/trie_viz/load.py
@@ -1,0 +1,35 @@
+"""Load trie-dump CSVs produced by dump-trie-hcltj."""
+
+import re
+from pathlib import Path
+
+import pandas as pd
+
+FULL_TRIES = {"SPO", "POS", "OSP"}
+CSV_PATTERN = re.compile(r"trie_(\d)_([A-Z]{3})_nodes\.csv")
+
+
+def load_trie_dumps(
+    outdir: str | Path,
+    full_only: bool = True,
+) -> dict[str, pd.DataFrame]:
+    """Load per-trie node CSVs from *outdir*.
+
+    Returns a dict keyed by trie name (e.g. "SPO") with DataFrames
+    containing columns: node, parent, depth, key, n_children.
+
+    If *full_only* is True (default), only loads full tries (SPO, POS, OSP)
+    since partial tries lack first-level keys.
+    """
+    outdir = Path(outdir)
+    result: dict[str, pd.DataFrame] = {}
+    for path in sorted(outdir.glob("trie_*_*_nodes.csv")):
+        m = CSV_PATTERN.match(path.name)
+        if m is None:
+            continue
+        name = m.group(2)
+        if full_only and name not in FULL_TRIES:
+            continue
+        df = pd.read_csv(path)
+        result[name] = df
+    return result

--- a/analysis/trie_viz/main.py
+++ b/analysis/trie_viz/main.py
@@ -1,0 +1,41 @@
+"""CLI: visualise trie structure from dump-trie-hcltj CSVs."""
+
+import argparse
+from pathlib import Path
+
+from load import load_trie_dumps
+from plot import plot_all_tries
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("outdir", help="Directory with trie_*_*_nodes.csv files")
+    parser.add_argument(
+        "--figdir",
+        help="Directory to save figures (default: outdir/figures)",
+    )
+    parser.add_argument(
+        "--all-tries",
+        action="store_true",
+        help="Include partial tries (default: full tries only)",
+    )
+    args = parser.parse_args()
+
+    outdir = Path(args.outdir)
+    figdir = Path(args.figdir) if args.figdir else outdir / "figures"
+
+    trie_dumps = load_trie_dumps(outdir, full_only=not args.all_tries)
+    if not trie_dumps:
+        print(f"No trie-dump CSVs found in {outdir}")
+        return
+
+    print(f"Loaded {len(trie_dumps)} tries: {', '.join(trie_dumps.keys())}")
+    for name, df in trie_dumps.items():
+        print(f"  {name}: {len(df)} nodes, max_depth={df['depth'].max()}")
+
+    plot_all_tries(trie_dumps, savedir=figdir)
+    print(f"\nFigures saved to {figdir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/trie_viz/plot.py
+++ b/analysis/trie_viz/plot.py
@@ -1,0 +1,96 @@
+"""Draw a metatrie as a tree using networkx + matplotlib."""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import networkx as nx
+import pandas as pd
+
+
+def _build_graph(df: pd.DataFrame) -> nx.DiGraph:
+    G = nx.DiGraph()
+    for idx, row in df.iterrows():
+        key = int(row["key"])
+        depth = int(row["depth"])
+        n_children = int(row["n_children"])
+        is_leaf = bool(row.get("is_leaf", False))
+        label = "root" if row["parent"] == -1 else str(key)
+        G.add_node(idx, label=label, depth=depth, n_children=n_children, is_leaf=is_leaf)
+        if row["parent"] != -1:
+            G.add_edge(int(row["parent"]), idx)
+    return G
+
+
+def _hierarchy_pos(
+    G: nx.DiGraph,
+    root: int,
+    width: float = 1.0,
+    y_gap: float = 1.0,
+) -> dict[int, tuple[float, float]]:
+    """Compute positions for a tree layout (root at top)."""
+    pos: dict[int, tuple[float, float]] = {}
+
+    def _place(node, left, right, depth):
+        children = list(G.successors(node))
+        pos[node] = ((left + right) / 2.0, -depth * y_gap)
+        if not children:
+            return
+        slot = (right - left) / len(children)
+        for i, child in enumerate(children):
+            _place(child, left + i * slot, left + (i + 1) * slot, depth + 1)
+
+    _place(root, 0.0, width, 0)
+    return pos
+
+
+def plot_trie(
+    df: pd.DataFrame,
+    title: str = "",
+    savepath: str | Path | None = None,
+    figsize: tuple[float, float] | None = None,
+) -> plt.Figure:
+    """Draw a single trie as a top-down tree."""
+    G = _build_graph(df)
+    root = int(df.index[df["parent"] == -1][0])
+    n_nodes = len(G)
+
+    if figsize is None:
+        figsize = (max(6, n_nodes * 0.6), max(4, df["depth"].max() * 2 + 1))
+
+    pos = _hierarchy_pos(G, root, width=n_nodes * 0.8)
+    labels = nx.get_node_attributes(G, "label")
+    is_leaf = nx.get_node_attributes(G, "is_leaf")
+
+    internal_nodes = [n for n, leaf in is_leaf.items() if not leaf]
+    leaf_nodes = [n for n, leaf in is_leaf.items() if leaf]
+
+    fig, ax = plt.subplots(figsize=figsize)
+    nx.draw_networkx_edges(G, pos, ax=ax, edge_color="#888", arrows=False)
+    nx.draw_networkx_nodes(G, pos, nodelist=internal_nodes, ax=ax,
+                           node_color="#a8d8ea", edgecolors="#333", node_size=600)
+    nx.draw_networkx_nodes(G, pos, nodelist=leaf_nodes, ax=ax,
+                           node_color="#d4edda", edgecolors="#555",
+                           node_size=400, node_shape="s")
+    nx.draw_networkx_labels(G, pos, labels=labels, ax=ax, font_size=8)
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    if savepath:
+        fig.savefig(savepath, dpi=150, bbox_inches="tight")
+    return fig
+
+
+def plot_all_tries(
+    trie_dumps: dict[str, pd.DataFrame],
+    savedir: str | Path | None = None,
+) -> list[plt.Figure]:
+    """Plot each trie and optionally save to *savedir*."""
+    if savedir:
+        savedir = Path(savedir)
+        savedir.mkdir(parents=True, exist_ok=True)
+    figs = []
+    for name, df in trie_dumps.items():
+        sp = (savedir / f"{name}.png") if savedir else None
+        fig = plot_trie(df, title=f"Trie {name}", savepath=sp)
+        figs.append(fig)
+    return figs

--- a/analysis/uv.lock
+++ b/analysis/uv.lock
@@ -12,6 +12,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "ipykernel" },
     { name = "matplotlib" },
+    { name = "networkx" },
     { name = "notebook" },
     { name = "pandas" },
     { name = "seaborn" },
@@ -22,6 +23,7 @@ dependencies = [
 requires-dist = [
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "matplotlib", specifier = ">=3.10.3" },
+    { name = "networkx", specifier = ">=3.2" },
     { name = "notebook", specifier = ">=7.4.4" },
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "seaborn", specifier = ">=0.13.2" },
@@ -1050,6 +1052,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195 },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504 },
 ]
 
 [[package]]

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -85,8 +85,8 @@ class MPHF {
     // management (e.g., rank support with pointer relationships to bitvectors).
     MPHF(const MPHF&) = delete;
     MPHF& operator=(const MPHF&) = delete;
-    MPHF(MPHF&&) = delete;
-    MPHF& operator=(MPHF&&) = delete;
+    MPHF(MPHF&&) = default;
+    MPHF& operator=(MPHF&&) = default;
 
     /**
      * @brief Build MPHF for given keys

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -81,8 +81,6 @@ class MPHF {
           biases_{0, 0, 0},
           segment_starts_{0, 0, 0} {}
 
-    // Disabling copy and move because storage strategy may have complex resource
-    // management (e.g., rank support with pointer relationships to bitvectors).
     MPHF(const MPHF&) = delete;
     MPHF& operator=(const MPHF&) = delete;
     MPHF(MPHF&&) = default;

--- a/include/hashing/storage/glgh.hpp
+++ b/include/hashing/storage/glgh.hpp
@@ -30,6 +30,25 @@ class GlGhStorage : public StorageStrategy<GlGhStorage> {
   public:
     GlGhStorage() : m_(0) {}
 
+    GlGhStorage(GlGhStorage&& o) noexcept
+        : Gl_(std::move(o.Gl_)), Gh_(std::move(o.Gh_)),
+          rank_B_(std::move(o.rank_B_)), m_(o.m_) {
+        rank_B_.set_vector(&Gl_);
+        rank_B_.set_gh(&Gh_);
+    }
+
+    GlGhStorage& operator=(GlGhStorage&& o) noexcept {
+        if (this != &o) {
+            Gl_ = std::move(o.Gl_);
+            Gh_ = std::move(o.Gh_);
+            rank_B_ = std::move(o.rank_B_);
+            m_ = o.m_;
+            rank_B_.set_vector(&Gl_);
+            rank_B_.set_gh(&Gh_);
+        }
+        return *this;
+    }
+
     /**
      * @brief Get G value for a vertex
      * 

--- a/include/index/cltj_index_metatrie.hpp
+++ b/include/index/cltj_index_metatrie.hpp
@@ -7,6 +7,7 @@
 
 #include <cltj_config.hpp>
 #include <metatrie/cltj_compact_metatrie.hpp>
+#include <metatrie/compact_metatrie_hash.hpp>
 
 namespace cltj {
 
@@ -276,6 +277,7 @@ public:
 };
 
 typedef cltj::cltj_index_metatrie<cltj::compact_metatrie> compact_ltj_metatrie;
+typedef cltj::cltj_index_metatrie<cltj::compact_metatrie_hash> compact_ltj_metatrie_hash;
 // typedef cltj::cltj_index_metatrie<cltj::uncompact_trie_v2> uncompact_ltj;
 
 } // namespace cltj

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -1,0 +1,167 @@
+#ifndef CLTJ_COMPACT_METATRIE_HASH_H
+#define CLTJ_COMPACT_METATRIE_HASH_H
+
+#include <cds/succ_support_v.hpp>
+#include <cltj_config.hpp>
+#include <fstream>
+#include <iostream>
+#include <queue>
+#include <sdsl/select_support_mcl.hpp>
+#include <sdsl/vectors.hpp>
+#include <string>
+#include <vector>
+
+namespace cltj {
+
+class compact_metatrie_hash {
+  public:
+    typedef uint64_t size_type;
+    typedef uint32_t value_type;
+
+  private:
+    sdsl::bit_vector m_bv;
+    sdsl::int_vector<> m_seq;
+    // sdsl::rank_support_v<1> m_rank1;
+    cds::succ_support_v<0> m_succ0;
+    sdsl::select_support_mcl<0> m_select0;
+
+    size_type m_root_degree;
+
+    void copy(const compact_metatrie_hash& o) {
+        m_bv = o.m_bv;
+        m_seq = o.m_seq;
+        // m_rank1 = o.m_rank1;
+        // m_rank1.set_vector(&m_bv);
+        m_succ0 = o.m_succ0;
+        m_succ0.set_vector(&m_bv);
+        m_select0 = o.m_select0;
+        m_select0.set_vector(&m_bv);
+        m_root_degree = o.m_root_degree;
+    }
+
+    /*inline size_type rank0(const size_type i) const {
+      return i - m_rank1(i);
+  }*/
+
+  public:
+    const sdsl::int_vector<>& seq = m_seq;
+
+    compact_metatrie_hash() = default;
+
+    compact_metatrie_hash(sdsl::bit_vector& _bv, sdsl::int_vector<>& _seq) {
+        m_bv = _bv;
+        m_seq = _seq;
+        sdsl::util::bit_compress(m_seq);
+        sdsl::util::init_support(m_succ0, &m_bv);
+        sdsl::util::init_support(m_select0, &m_bv);
+        m_root_degree = m_succ0(1);
+    }
+
+    //! Copy constructor
+    compact_metatrie_hash(const compact_metatrie_hash& o) { copy(o); }
+
+    //! Move constructor
+    compact_metatrie_hash(compact_metatrie_hash&& o) { *this = std::move(o); }
+
+    //! Copy Operator=
+    compact_metatrie_hash& operator=(const compact_metatrie_hash& o) {
+        if (this != &o) {
+            copy(o);
+        }
+        return *this;
+    }
+
+    //! Move Operator=
+    compact_metatrie_hash& operator=(compact_metatrie_hash&& o) {
+        if (this != &o) {
+            m_bv = std::move(o.m_bv);
+            m_seq = std::move(o.m_seq);
+            // m_rank1 = std::move(o.m_rank1);
+            m_succ0 = std::move(o.m_succ0);
+            // m_rank1.set_vector(&m_bv);
+            m_succ0.set_vector(&m_bv);
+            m_select0 = std::move(o.m_select0);
+            m_select0.set_vector(&m_bv);
+            m_root_degree = o.m_root_degree;
+        }
+        return *this;
+    }
+
+    void swap(compact_metatrie_hash& o) {
+        // m_bp.swap(bp_support.m_bp); use set_vector to set the supported
+        // bit_vector
+        std::swap(m_bv, o.m_bv);
+        std::swap(m_seq, o.m_seq);
+        sdsl::util::swap_support(m_succ0, o.m_succ0, &m_bv, &o.m_bv);
+        sdsl::util::swap_support(m_select0, o.m_select0, &m_bv, &o.m_bv);
+        std::swap(m_root_degree, o.m_root_degree);
+    }
+
+    /*
+      Degree of the trie root
+  */
+
+    size_type root_degree() const { return m_root_degree; }
+
+    /*
+      Receives index of current node and the child that is required
+      Returns index of the nth child of current node
+  */
+    inline size_type child(uint32_t it, uint32_t n) const { return m_select0(it + 1 + n); }
+
+    /*
+      Receives index of node whos children we want to count
+      Returns how many children said node has
+  */
+    size_type children(size_type i) const { return m_succ0(i + 1) - i; }
+
+    size_type first_child(size_type i) const { return i; }
+
+    inline size_type nodeselect(size_type i) const { return m_select0(i + 2); }
+
+    pair<uint32_t, uint32_t> binary_search_seek(uint32_t val, uint32_t i, uint32_t f) const {
+        if (m_seq[f] < val)
+            return make_pair(0, f + 1);
+        uint32_t mid;
+        while (i < f) {
+            mid = (i + f) / 2;
+            if (m_seq[mid] < val) {
+                i = mid + 1;
+            } else {
+                f = mid;
+            }
+        }
+        return make_pair(m_seq[i], i);
+    }
+
+    void print() const {
+        for (size_type i = 0; i < m_bv.size(); ++i) {
+            std::cout << (uint)m_bv[i];
+        }
+        std::cout << std::endl;
+    }
+
+    //! Serializes the data structure into the given ostream
+    size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "")
+        const {
+        sdsl::structure_tree_node* child =
+            sdsl::structure_tree::add_child(v, name, sdsl::util::class_name(*this));
+        size_type written_bytes = 0;
+        written_bytes += m_bv.serialize(out, child, "bv");
+        written_bytes += m_seq.serialize(out, child, "seq");
+        written_bytes += m_succ0.serialize(out, child, "succ0");
+        written_bytes += m_select0.serialize(out, child, "select0");
+        sdsl::structure_tree::add_size(child, written_bytes);
+        return written_bytes;
+    }
+
+    void load(std::istream& in) {
+        m_bv.load(in);
+        m_seq.load(in);
+        m_succ0.load(in, &m_bv);
+        m_select0.load(in, &m_bv);
+        m_root_degree = m_succ0(1);
+    }
+};
+}  // namespace cltj
+#endif

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -38,17 +38,8 @@ class compact_metatrie_hash {
     sdsl::rank_support_v<1> m_hash_rank;
     uint32_t m_threshold = 0;
 
-    void copy(const compact_metatrie_hash& o) {
-        m_bv = o.m_bv;
-        m_seq = o.m_seq;
-        // m_rank1 = o.m_rank1;
-        // m_rank1.set_vector(&m_bv);
-        m_succ0 = o.m_succ0;
-        m_succ0.set_vector(&m_bv);
-        m_select0 = o.m_select0;
-        m_select0.set_vector(&m_bv);
-        m_root_degree = o.m_root_degree;
-    }
+    // Copy is disabled: std::vector<mphf_type> is not copyable (MPHF copy is deleted by design).
+    // Might change in the future if we find a good reason to copy it.
 
     /*inline size_type rank0(const size_type i) const {
       return i - m_rank1(i);
@@ -68,19 +59,11 @@ class compact_metatrie_hash {
         m_root_degree = m_succ0(1);
     }
 
-    //! Copy constructor
-    compact_metatrie_hash(const compact_metatrie_hash& o) { copy(o); }
+    compact_metatrie_hash(const compact_metatrie_hash&) = delete;
+    compact_metatrie_hash& operator=(const compact_metatrie_hash&) = delete;
 
     //! Move constructor
     compact_metatrie_hash(compact_metatrie_hash&& o) { *this = std::move(o); }
-
-    //! Copy Operator=
-    compact_metatrie_hash& operator=(const compact_metatrie_hash& o) {
-        if (this != &o) {
-            copy(o);
-        }
-        return *this;
-    }
 
     //! Move Operator=
     compact_metatrie_hash& operator=(compact_metatrie_hash&& o) {
@@ -94,6 +77,11 @@ class compact_metatrie_hash {
             m_select0 = std::move(o.m_select0);
             m_select0.set_vector(&m_bv);
             m_root_degree = o.m_root_degree;
+            m_mphfs = std::move(o.m_mphfs);
+            m_has_hash = std::move(o.m_has_hash);
+            m_hash_rank = std::move(o.m_hash_rank);
+            m_hash_rank.set_vector(&m_has_hash);
+            m_threshold = o.m_threshold;
         }
         return *this;
     }

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -103,6 +103,8 @@ class compact_metatrie_hash {
 
     size_type root_degree() const { return m_root_degree; }
 
+    size_type mphf_count() const { return m_mphfs.size(); }
+
     /*
       Receives index of current node and the child that is required
       Returns index of the nth child of current node
@@ -156,6 +158,53 @@ class compact_metatrie_hash {
         size_type n_children;
         bool is_leaf;
     };
+
+    /**
+     * @brief Builds MPHF for every node with >= threshold children.
+     *
+     * Walks the LOUDS in BFS order
+     * For each node whose out-degree meets the threshold, extracts the keys
+     * from m_seq and builds an MPHF.  m_has_hash[node_pos] is set to 1 for
+     * each such node, and m_hash_rank is rebuilt over the updated bitvector.
+     */
+    void build_hash_overlay(uint32_t threshold) {
+        m_threshold = threshold;
+        m_has_hash = sdsl::bit_vector(m_bv.size(), 0);
+        m_mphfs.clear();
+
+        size_type num_zeros = 0;
+        for (size_type i = 0; i < m_bv.size(); i++)
+            if (!m_bv[i])
+                num_zeros++;
+
+        std::vector<size_type> current_level = {0};
+        while (!current_level.empty()) {
+            std::vector<size_type> next_level;
+            for (auto node : current_level) {
+                size_type n_children = children(node);
+                if (n_children >= threshold) {
+                    std::vector<uint64_t> keys;
+                    keys.reserve(n_children);
+                    for (size_type k = 0; k < n_children; k++)
+                        keys.push_back(static_cast<uint64_t>(m_seq[node + k]));
+                    mphf_type mphf;
+                    if (mphf.build(keys)) {
+                        m_has_hash[node] = 1;
+                        m_mphfs.push_back(std::move(mphf));
+                    }
+                }
+                for (size_type n = 1; n <= n_children; n++) {
+                    if (node + 1 + n > num_zeros)
+                        break;
+                    size_type child_node = child(node, n);
+                    if (child_node + 1 < m_bv.size())
+                        next_level.push_back(child_node);
+                }
+            }
+            current_level = std::move(next_level);
+        }
+        sdsl::util::init_support(m_hash_rank, &m_has_hash);
+    }
 
     /**
      * @brief Returns one NodeInfo per node in BFS order, including leaf nodes.

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -149,6 +149,69 @@ class compact_metatrie_hash {
         return hist;
     }
 
+    struct NodeInfo {
+        size_type node;
+        int64_t parent;  // -1 for the root (depth == 0)
+        uint32_t depth;
+        uint32_t key;  // value in m_seq at this node's position; 0 for the root
+        size_type n_children;
+    };
+
+    /**
+     * @brief Returns one NodeInfo per internal node in BFS order.
+     *
+     * In this LOUDS encoding, a node at position p stores its *children's*
+     * keys at m_seq[p .. p + children(p) - 1].  The node's own key lives
+     * in its parent's m_seq range.  Therefore the key is passed from parent
+     * to child during BFS, and the root (parent == -1) gets key = 0.
+     *
+     * For partial tries (SOP, PSO, OPS) the first-level keys are not stored
+     * in the trie at all (they come from the full trie via trie switching).
+     * In that case, first-level nodes appear with key = 0 and depth = 0.
+     * Their children carry the correct second-level keys from m_seq.
+     * The LOUDS navigation also links subsequent first-level nodes as
+     * "children" of the first one, which is a navigation artifact, not a
+     * semantic parent-child relationship.
+     */
+    std::vector<NodeInfo> dump_nodes() const {
+        std::vector<NodeInfo> nodes;
+
+        size_type num_zeros = 0;
+        for (size_type i = 0; i < m_bv.size(); i++)
+            if (!m_bv[i])
+                num_zeros++;
+
+        struct BFSEntry {
+            size_type node;
+            int64_t parent;
+            uint32_t depth;
+            uint32_t key;
+        };
+
+        std::vector<BFSEntry> current_level = {
+            {0, -1, 0, 0}
+        };
+        while (!current_level.empty()) {
+            std::vector<BFSEntry> next_level;
+            for (auto& [node, parent, depth, key] : current_level) {
+                size_type d = children(node);
+                nodes.push_back({node, parent, depth, key, d});
+
+                for (size_type n = 1; n <= d; n++) {
+                    if (node + 1 + n > num_zeros)
+                        break;
+                    size_type child_node = child(node, n);
+                    uint32_t child_key = static_cast<uint32_t>(m_seq[node + n - 1]);
+                    if (child_node + 1 < m_bv.size())
+                        next_level.push_back({child_node, static_cast<int64_t>(node), depth + 1, child_key});
+                }
+            }
+            current_level = std::move(next_level);
+        }
+
+        return nodes;
+    }
+
     inline size_type nodeselect(size_type i) const { return m_select0(i + 2); }
 
     pair<uint32_t, uint32_t> binary_search_seek(uint32_t val, uint32_t i, uint32_t f) const {

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -105,6 +105,13 @@ class compact_metatrie_hash {
 
     size_type mphf_count() const { return m_mphfs.size(); }
 
+    bool node_has_hash(size_type node_pos) const { return m_has_hash[node_pos]; }
+
+    bool hash_contains(size_type node_pos, value_type key) const {
+        size_type mphf_idx = m_hash_rank(node_pos);
+        return m_mphfs[mphf_idx].contains(static_cast<uint64_t>(key));
+    }
+
     /*
       Receives index of current node and the child that is required
       Returns index of the nth child of current node

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -150,6 +150,13 @@ class compact_metatrie_hash {
         written_bytes += m_seq.serialize(out, child, "seq");
         written_bytes += m_succ0.serialize(out, child, "succ0");
         written_bytes += m_select0.serialize(out, child, "select0");
+        written_bytes += sdsl::write_member(m_threshold, out, child, "threshold");
+        written_bytes += m_has_hash.serialize(out, child, "has_hash");
+        written_bytes += m_hash_rank.serialize(out, child, "hash_rank");
+        uint32_t n = m_mphfs.size();
+        written_bytes += sdsl::write_member(n, out, child, "n_mphfs");
+        for (auto& mphf : m_mphfs)
+            written_bytes += mphf.serialize(out, child, "mphf");
         sdsl::structure_tree::add_size(child, written_bytes);
         return written_bytes;
     }
@@ -160,6 +167,14 @@ class compact_metatrie_hash {
         m_succ0.load(in, &m_bv);
         m_select0.load(in, &m_bv);
         m_root_degree = m_succ0(1);
+        sdsl::read_member(m_threshold, in);
+        m_has_hash.load(in);
+        m_hash_rank.load(in, &m_has_hash);
+        uint32_t n;
+        sdsl::read_member(n, in);
+        m_mphfs.resize(n);
+        for (auto& mphf : m_mphfs)
+            mphf.load(in);
     }
 };
 }  // namespace cltj

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -117,6 +117,10 @@ class compact_metatrie_hash {
 
     size_type first_child(size_type i) const { return i; }
 
+    /**
+     * @brief Computes a histogram of node out-degrees in the metatrie.
+     * @return A map where key = number of children and value = node count.
+     */
     std::map<size_type, size_type> children_histogram() const {
         std::map<size_type, size_type> hist;
 

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -10,6 +10,8 @@
 #include <sdsl/vectors.hpp>
 #include <string>
 #include <vector>
+#include <hashing/mphf_bdz.hpp>
+#include <hashing/storage/glgh.hpp>
 
 namespace cltj {
 
@@ -19,6 +21,8 @@ class compact_metatrie_hash {
     typedef uint32_t value_type;
 
   private:
+    using mphf_type = hashing::MPHF<hashing::GlGhStorage, hashing::policies::QuotientKey>;
+
     sdsl::bit_vector m_bv;
     sdsl::int_vector<> m_seq;
     // sdsl::rank_support_v<1> m_rank1;
@@ -26,6 +30,13 @@ class compact_metatrie_hash {
     sdsl::select_support_mcl<0> m_select0;
 
     size_type m_root_degree;
+
+    // Hash overlay
+    // TODO: Empty until Batch 2 builds MPHFs
+    std::vector<mphf_type> m_mphfs;
+    sdsl::bit_vector m_has_hash;
+    sdsl::rank_support_v<1> m_hash_rank;
+    uint32_t m_threshold = 0;
 
     void copy(const compact_metatrie_hash& o) {
         m_bv = o.m_bv;

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -150,28 +150,31 @@ class compact_metatrie_hash {
     }
 
     struct NodeInfo {
-        size_type node;
-        int64_t parent;  // -1 for the root (depth == 0)
+        int64_t parent;  // row index of parent in the output vector; -1 for the root
         uint32_t depth;
-        uint32_t key;  // value in m_seq at this node's position; 0 for the root
+        uint32_t key;  // 0 for the virtual root
         size_type n_children;
+        bool is_leaf;
     };
 
     /**
-     * @brief Returns one NodeInfo per internal node in BFS order.
+     * @brief Returns one NodeInfo per node in BFS order, including leaf nodes.
+     *
+     * Each entry's parent field is the 0-based row index of its parent in
+     * the returned vector.  The root has parent = -1.
      *
      * In this LOUDS encoding, a node at position p stores its *children's*
      * keys at m_seq[p .. p + children(p) - 1].  The node's own key lives
-     * in its parent's m_seq range.  Therefore the key is passed from parent
-     * to child during BFS, and the root (parent == -1) gets key = 0.
+     * in its parent's m_seq range.  The key is passed from parent to child
+     * during BFS, and the virtual root gets key = 0.
+     *
+     * The last-level nodes (e.g. O-values in full tries) are not encoded in
+     * the BV.  Their keys are read from m_seq and emitted as leaf entries
+     * (is_leaf = true, n_children = 0).
      *
      * For partial tries (SOP, PSO, OPS) the first-level keys are not stored
-     * in the trie at all (they come from the full trie via trie switching).
-     * In that case, first-level nodes appear with key = 0 and depth = 0.
-     * Their children carry the correct second-level keys from m_seq.
-     * The LOUDS navigation also links subsequent first-level nodes as
-     * "children" of the first one, which is a navigation artifact, not a
-     * semantic parent-child relationship.
+     * in the trie (they come from the full trie via trie switching).
+     * First-level nodes therefore appear with key = 0.
      */
     std::vector<NodeInfo> dump_nodes() const {
         std::vector<NodeInfo> nodes;
@@ -182,8 +185,8 @@ class compact_metatrie_hash {
                 num_zeros++;
 
         struct BFSEntry {
-            size_type node;
-            int64_t parent;
+            size_type louds_pos;
+            int64_t parent_idx;
             uint32_t depth;
             uint32_t key;
         };
@@ -193,17 +196,23 @@ class compact_metatrie_hash {
         };
         while (!current_level.empty()) {
             std::vector<BFSEntry> next_level;
-            for (auto& [node, parent, depth, key] : current_level) {
-                size_type d = children(node);
-                nodes.push_back({node, parent, depth, key, d});
+            for (auto& e : current_level) {
+                size_type d = children(e.louds_pos);
+                int64_t my_idx = static_cast<int64_t>(nodes.size());
+                nodes.push_back({e.parent_idx, e.depth, e.key, d, false});
 
                 for (size_type n = 1; n <= d; n++) {
-                    if (node + 1 + n > num_zeros)
-                        break;
-                    size_type child_node = child(node, n);
-                    uint32_t child_key = static_cast<uint32_t>(m_seq[node + n - 1]);
-                    if (child_node + 1 < m_bv.size())
-                        next_level.push_back({child_node, static_cast<int64_t>(node), depth + 1, child_key});
+                    uint32_t child_key = static_cast<uint32_t>(m_seq[e.louds_pos + n - 1]);
+                    if (e.louds_pos + 1 + n > num_zeros) {
+                        nodes.push_back({my_idx, e.depth + 1, child_key, 0, true});
+                    } else {
+                        size_type child_pos = child(e.louds_pos, n);
+                        if (child_pos + 1 < m_bv.size()) {
+                            next_level.push_back({child_pos, my_idx, e.depth + 1, child_key});
+                        } else {
+                            nodes.push_back({my_idx, e.depth + 1, child_key, 0, true});
+                        }
+                    }
                 }
             }
             current_level = std::move(next_level);

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -5,6 +5,7 @@
 #include <cltj_config.hpp>
 #include <fstream>
 #include <iostream>
+#include <map>
 #include <queue>
 #include <sdsl/select_support_mcl.hpp>
 #include <sdsl/vectors.hpp>
@@ -115,6 +116,34 @@ class compact_metatrie_hash {
     size_type children(size_type i) const { return m_succ0(i + 1) - i; }
 
     size_type first_child(size_type i) const { return i; }
+
+    std::map<size_type, size_type> children_histogram() const {
+        std::map<size_type, size_type> hist;
+
+        size_type num_zeros = 0;
+        for (size_type i = 0; i < m_bv.size(); i++)
+            if (!m_bv[i])
+                num_zeros++;
+
+        std::vector<size_type> current_level = {0};
+        while (!current_level.empty()) {
+            std::vector<size_type> next_level;
+            for (auto node : current_level) {
+                size_type d = children(node);
+                hist[d]++;
+                for (size_type n = 1; n <= d; n++) {
+                    if (node + 1 + n > num_zeros)
+                        break;
+                    size_type child_node = child(node, n);
+                    if (child_node + 1 < m_bv.size())
+                        next_level.push_back(child_node);
+                }
+            }
+            current_level = std::move(next_level);
+        }
+
+        return hist;
+    }
 
     inline size_type nodeselect(size_type i) const { return m_select0(i + 2); }
 

--- a/include/query/ltj_algorithm_hash.hpp
+++ b/include/query/ltj_algorithm_hash.hpp
@@ -393,50 +393,87 @@ class ltj_algorithm_hash {
                     m_veo.up();
                 }
             } else {
+                // Compute children sizes
+                std::vector<size_type> children_sizes(itrs.size());
+                size_type min_idx = 0;
+                for (size_type i = 0; i < itrs.size(); ++i) {
+                    state_type state = o;
+                    if (itrs[i]->is_variable_subject(x_j))
+                        state = s;
+                    else if (itrs[i]->is_variable_predicate(x_j))
+                        state = p;
+                    children_sizes[i] = itrs[i]->children(state);
+                    if (children_sizes[i] < children_sizes[min_idx])
+                        min_idx = i;
+                }
+
                 // TODO: Make stats optional
                 IntersectionStats stats;
                 stats.variable_id = x_j;
                 stats.depth = j;
+                stats.list_sizes.assign(children_sizes.begin(), children_sizes.end());
 
-                // Collect list sizes from each iterator
-                for (ltj_iter_type* iter : itrs) {
-                    // Determine which state/variable this iterator represents
-                    state_type state = o;  // default
-                    if (iter->is_variable_subject(x_j)) {
-                        state = s;
-                    } else if (iter->is_variable_predicate(x_j)) {
-                        state = p;
-                    }
-                    stats.list_sizes.push_back(iter->children(state));
-                }
+                if (itrs[min_idx]->current_node_has_hash(x_j)) {
+                    // HASH PATH: scan smallest list, O(1) membership check on others
+                    auto [beg, end_pos] = itrs[min_idx]->children_range();
 
-                value_type c = seek(x_j);
-                // cout << "Seek (init): (" << (uint64_t) x_j << ": " << c << ")"
-                // <<endl;
-                while (c != 0) {  // If empty c=0
-                    // Count each result found
-                    stats.result_size++;
+                    for (size_type pos = beg; pos < end_pos; ++pos) {
+                        value_type c = itrs[min_idx]->child_value_at(pos);
 
-                    // 1. Adding result to tuple
-                    tuple[j] = {x_j, c};
-                    // 2. Going down in the tries by setting x_j = c (\mu(t_i) in paper)
-                    for (ltj_iter_type* iter : itrs) {
-                        iter->down(x_j, c);
+                        bool in_all = true;
+                        for (size_type i = 0; i < itrs.size(); ++i) {
+                            if (i == min_idx)
+                                continue;
+                            if (!itrs[i]->hash_contains(x_j, c)) {
+                                in_all = false;
+                                break;
+                            }
+                        }
+
+                        if (in_all) {
+                            stats.result_size++;
+                            tuple[j] = {x_j, c};
+
+                            for (ltj_iter_type* iter : itrs) {
+                                state_type st = o;
+                                if (iter->is_variable_subject(x_j))
+                                    st = s;
+                                else if (iter->is_variable_predicate(x_j))
+                                    st = p;
+                                iter->exists(st, c);
+                            }
+                            for (ltj_iter_type* iter : itrs) {
+                                iter->down(x_j, c);
+                            }
+                            m_veo.down();
+                            ok = search(j + 1, tuple, res, start, limit_results, timeout_seconds);
+                            if (!ok)
+                                return false;
+                            for (ltj_iter_type* iter : itrs) {
+                                iter->up(x_j);
+                            }
+                            m_veo.up();
+                        }
                     }
-                    m_veo.down();
-                    // 3. Search with the next variable x_{j+1}
-                    ok = search(j + 1, tuple, res, start, limit_results, timeout_seconds);
-                    if (!ok)
-                        return false;
-                    // 4. Going up in the tries by removing x_j = c
-                    for (ltj_iter_type* iter : itrs) {
-                        iter->up(x_j);
+                } else {
+                    // LEAPFROG PATH: unchanged
+                    value_type c = seek(x_j);
+                    while (c != 0) {  // If empty c=0
+                        stats.result_size++;
+                        tuple[j] = {x_j, c};
+                        for (ltj_iter_type* iter : itrs) {
+                            iter->down(x_j, c);
+                        }
+                        m_veo.down();
+                        ok = search(j + 1, tuple, res, start, limit_results, timeout_seconds);
+                        if (!ok)
+                            return false;
+                        for (ltj_iter_type* iter : itrs) {
+                            iter->up(x_j);
+                        }
+                        m_veo.up();
+                        c = seek(x_j, c + 1);
                     }
-                    m_veo.up();
-                    // 5. Next constant for x_j
-                    c = seek(x_j, c + 1);
-                    // cout << "Seek (bucle): (" << (uint64_t) x_j << ": " << c << ")"
-                    // <<endl;
                 }
 
                 // TODO: Make stats optional

--- a/include/query/ltj_algorithm_hash.hpp
+++ b/include/query/ltj_algorithm_hash.hpp
@@ -1,0 +1,527 @@
+/*
+ * ltj_algorithm_hash.hpp
+ * Copyright (C) 2020 Author removed for double-blind evaluation
+ *
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef RING_LTJ_ALGORITHM_HASH_HPP
+#define RING_LTJ_ALGORITHM_HASH_HPP
+
+#include <triple_pattern.hpp>
+// #include <ltj_iterator.hpp>
+#include <dict/dict_map.hpp>
+#include <query/alternation_complexity.hpp>
+#include <query/intersection_stats.hpp>
+#include <query/ltj_iterator_basic.hpp>
+#include <query/ltj_iterator_lite.hpp>
+#include <query/ltj_iterator_metatrie_hash.hpp>
+#include <results/results.hpp>
+#include <util/rdf_util.hpp>
+#include <veo/veo_adaptive.hpp>
+#include <veo/veo_simple.hpp>
+
+#define EXPT_TIME_SOL 0
+
+namespace ltj {
+
+template <
+    class iterator_t = ltj_iterator_lite<cltj::compact_ltj, uint8_t, uint64_t>,
+    class veo_t = veo::veo_adaptive<iterator_t, util::trait_size>>
+class ltj_algorithm_hash {
+  public:
+    typedef uint64_t value_type;
+    typedef uint64_t size_type;
+    typedef iterator_t ltj_iter_type;
+    typedef typename ltj_iter_type::var_type var_type;
+    typedef typename ltj_iter_type::index_scheme_type index_scheme_type;
+    typedef typename ltj_iter_type::value_type const_type;
+    typedef veo_t veo_type;
+    typedef unordered_map<var_type, vector<ltj_iter_type*>> var_to_iterators_type;
+    typedef vector<pair<var_type, const_type>> tuple_type;
+    typedef vector<std::string> tuple_str_type;
+    typedef chrono::high_resolution_clock::time_point time_point_type;
+    // typedef ::util::results_collector<tuple_type> results_type;
+
+  private:
+    const vector<triple_pattern>* m_ptr_triple_patterns;
+    veo_type m_veo;
+    index_scheme_type* m_ptr_ring;
+    vector<ltj_iter_type> m_iterators;
+    var_to_iterators_type m_var_to_iterators;
+    bool m_is_empty = false;
+    std::vector<IntersectionStats> m_stats;
+
+    void copy(const ltj_algorithm_hash& o) {
+        m_ptr_triple_patterns = o.m_ptr_triple_patterns;
+        m_veo = o.m_veo;
+        m_ptr_ring = o.m_ptr_ring;
+        m_iterators = o.m_iterators;
+        m_var_to_iterators = o.m_var_to_iterators;
+        m_is_empty = o.m_is_empty;
+        m_stats = o.m_stats;
+    }
+
+    inline void add_var_to_iterator(const var_type var, ltj_iter_type* ptr_iterator) {
+        auto it = m_var_to_iterators.find(var);
+        if (it != m_var_to_iterators.end()) {
+            it->second.push_back(ptr_iterator);
+        } else {
+            vector<ltj_iter_type*> vec = {ptr_iterator};
+            m_var_to_iterators.insert({var, vec});
+        }
+    }
+
+    void from_id_to_str(
+        tuple_type& t,
+        tuple_str_type& t_str,
+        const std::vector<bool>& in_p,
+        dict::basic_map& dict_so,
+        dict::basic_map& dict_p
+    ) {
+        for (auto& p : t) {
+            if (in_p[p.first]) {
+                t_str[p.first] = dict_p.extract(p.second);
+            } else {
+                t_str[p.first] = dict_so.extract(p.second);
+            }
+        }
+    }
+
+  public:
+    const std::vector<IntersectionStats>& get_stats() const { return m_stats; }
+
+    ltj_algorithm_hash() = default;
+
+    ltj_algorithm_hash(const vector<triple_pattern>* triple_patterns, index_scheme_type* ring) {
+        m_ptr_triple_patterns = triple_patterns;
+        m_ptr_ring = ring;
+
+        size_type i = 0;
+        m_iterators.reserve(m_ptr_triple_patterns->size());
+        for (const auto& triple : *m_ptr_triple_patterns) {
+            // Bulding iterators
+            m_iterators.emplace_back(ltj_iter_type(&triple, m_ptr_ring));
+            if (m_iterators[i].is_empty()) {
+                m_is_empty = true;
+                return;
+            }
+
+            // For each variable we add the pointers to its iterators
+            if (triple.o_is_variable()) {
+                add_var_to_iterator(triple.term_o.value, &(m_iterators[i]));
+            }
+            if (triple.p_is_variable()) {
+                add_var_to_iterator(triple.term_p.value, &(m_iterators[i]));
+            }
+            if (triple.s_is_variable()) {
+                add_var_to_iterator(triple.term_s.value, &(m_iterators[i]));
+            }
+            ++i;
+        }
+
+        m_veo = veo_type(m_ptr_triple_patterns, &m_iterators, &m_var_to_iterators, m_ptr_ring);
+    }
+
+    //! Copy constructor
+    ltj_algorithm_hash(const ltj_algorithm_hash& o) { copy(o); }
+
+    //! Move constructor
+    ltj_algorithm_hash(ltj_algorithm_hash&& o) { *this = move(o); }
+
+    //! Copy Operator=
+    ltj_algorithm_hash& operator=(const ltj_algorithm_hash& o) {
+        if (this != &o) {
+            copy(o);
+        }
+        return *this;
+    }
+
+    //! Move Operator=
+    ltj_algorithm_hash& operator=(ltj_algorithm_hash&& o) {
+        if (this != &o) {
+            m_ptr_triple_patterns = move(o.m_ptr_triple_patterns);
+            m_veo = move(o.m_veo);
+            m_ptr_ring = move(o.m_ptr_ring);
+            m_iterators = move(o.m_iterators);
+            m_var_to_iterators = move(o.m_var_to_iterators);
+            m_is_empty = o.m_is_empty;
+            m_stats = move(o.m_stats);
+        }
+        return *this;
+    }
+
+    void swap(ltj_algorithm_hash& o) {
+        std::swap(m_ptr_triple_patterns, o.m_ptr_triple_patterns);
+        std::swap(m_veo, o.m_veo);
+        std::swap(m_ptr_ring, o.m_ptr_ring);
+        std::swap(m_iterators, o.m_iterators);
+        std::swap(m_var_to_iterators, o.m_var_to_iterators);
+        std::swap(m_is_empty, o.m_is_empty);
+        std::swap(m_stats, o.m_stats);
+    }
+
+    /**
+   *
+   * @param res               Results
+   * @param limit_results     Limit of results
+   * @param timeout_seconds   Timeout in seconds
+   */
+    template <class results_type>
+    void join(/*vector<tuple_type> &res,*/
+              results_type& res,
+              const size_type limit_results = 0,
+              const size_type timeout_seconds = 0
+    ) {
+        if (m_is_empty)
+            return;
+        time_point_type start = chrono::high_resolution_clock::now();
+        tuple_type t(m_veo.size());
+        search(0, t, res, start, limit_results, timeout_seconds);
+    };
+
+    /**
+   *
+   * @param res               Results
+   * @param limit_results     Limit of results
+   * @param timeout_seconds   Timeout in seconds
+   */
+    template <class results_type>
+    void join_str(/*vector<tuple_type> &res,*/
+                  results_type& res,
+                  const std::vector<bool>& in_p,
+                  dict::basic_map& dict_so,
+                  dict::basic_map& dict_p,
+                  const size_type limit_results = 0,
+                  const size_type timeout_seconds = 0
+    ) {
+        if (m_is_empty)
+            return;
+        time_point_type start = chrono::high_resolution_clock::now();
+        tuple_type t(m_veo.size());
+        tuple_str_type t_str(m_veo.size());
+        search_str(0, t, t_str, res, in_p, dict_so, dict_p, start, limit_results, timeout_seconds);
+    };
+
+    /**
+   *
+   * @param j                 Index of the variable
+   * @param tuple             Tuple of the current search
+   * @param res               Results
+   * @param start             Initial time to check timeout
+   * @param limit_results     Limit of results
+   * @param timeout_seconds   Timeout in seconds
+   */
+    template <class results_type>
+    bool search_str(
+        const size_type j,
+        tuple_type& tuple,
+        tuple_str_type& t_str,
+        results_type& res,
+        const std::vector<bool>& in_p,
+        dict::basic_map& dict_so,
+        dict::basic_map& dict_p,
+        const time_point_type start,
+        const size_type limit_results = 0,
+        const size_type timeout_seconds = 0
+    ) {
+        //(Optional) Check timeout
+        if (timeout_seconds > 0) {
+            time_point_type stop = chrono::high_resolution_clock::now();
+            auto sec = chrono::duration_cast<chrono::seconds>(stop - start).count();
+            if (sec > timeout_seconds) {
+                return false;
+            }
+        }
+
+        //(Optional) Check limit
+        if (limit_results > 0 && res.size() == limit_results) {
+            return false;
+        }
+
+        if (j == m_veo.size()) {
+            // Report results
+            // res.emplace_back(tuple);
+            from_id_to_str(tuple, t_str, in_p, dict_so, dict_p);
+            res.add(t_str);
+        } else {
+            var_type x_j = m_veo.next();
+            // cout << "Variable: " << (uint64_t) x_j << endl;
+            // cout << (uint64_t) x_j << endl;
+            vector<ltj_iter_type*>& itrs = m_var_to_iterators[x_j];
+            bool ok;
+            if (itrs.size() == 1 && itrs[0]->in_last_level()) {  // Lonely variables
+                // cout << "Seeking (last level)" << endl;
+                auto results = itrs[0]->seek_all(x_j);
+                // cout << "Results: " << results.size() << endl;
+                // cout << "Seek (last level): (" << (uint64_t) x_j << ": size=" <<
+                // results.size() << ")" <<endl;
+                for (const auto& c : results) {
+                    // 1. Adding result to tuple
+                    tuple[j] = {x_j, c};
+                    // 2. Going down in the trie by setting x_j = c (\mu(t_i) in paper)
+                    itrs[0]->down(x_j, c);
+                    m_veo.down();
+                    // 2. Search with the next variable x_{j+1}
+                    ok = search_str(
+                        j + 1, tuple, t_str, res, in_p, dict_so, dict_p, start, limit_results, timeout_seconds
+                    );
+                    if (!ok)
+                        return false;
+                    // 4. Going up in the trie by removing x_j = c
+                    itrs[0]->up(x_j);
+                    m_veo.up();
+                }
+            } else {
+                value_type c = seek(x_j);
+                // cout << "Seek (init): (" << (uint64_t) x_j << ": " << c << ")"
+                // <<endl;
+                while (c != 0) {  // If empty c=0
+                    // 1. Adding result to tuple
+                    tuple[j] = {x_j, c};
+                    // 2. Going down in the tries by setting x_j = c (\mu(t_i) in paper)
+                    for (ltj_iter_type* iter : itrs) {
+                        iter->down(x_j, c);
+                    }
+                    m_veo.down();
+                    // 3. Search with the next variable x_{j+1}
+                    ok = search_str(
+                        j + 1, tuple, t_str, res, in_p, dict_so, dict_p, start, limit_results, timeout_seconds
+                    );
+                    if (!ok)
+                        return false;
+                    // 4. Going up in the tries by removing x_j = c
+                    for (ltj_iter_type* iter : itrs) {
+                        iter->up(x_j);
+                    }
+                    m_veo.up();
+                    // 5. Next constant for x_j
+                    c = seek(x_j, c + 1);
+                    // cout << "Seek (bucle): (" << (uint64_t) x_j << ": " << c << ")"
+                    // <<endl;
+                }
+            }
+            m_veo.done();
+        }
+        return true;
+    };
+
+    /**
+   *
+   * @param j                 Index of the variable
+   * @param tuple             Tuple of the current search
+   * @param res               Results
+   * @param start             Initial time to check timeout
+   * @param limit_results     Limit of results
+   * @param timeout_seconds   Timeout in seconds
+   */
+    template <class results_type>
+    bool search(
+        const size_type j,
+        tuple_type& tuple,
+        results_type& res,
+        const time_point_type start,
+        const size_type limit_results = 0,
+        const size_type timeout_seconds = 0
+    ) {
+        //(Optional) Check timeout
+        if (timeout_seconds > 0) {
+            time_point_type stop = chrono::high_resolution_clock::now();
+            auto sec = chrono::duration_cast<chrono::seconds>(stop - start).count();
+            if (sec > timeout_seconds) {
+                return false;
+            }
+        }
+
+        //(Optional) Check limit
+        if (limit_results > 0 && res.size() == limit_results) {
+            return false;
+        }
+
+        if (j == m_veo.size()) {
+            // Report results
+            // res.emplace_back(tuple);
+            res.add(tuple);
+#if EXPT_TIME_SOL
+            if (res.size() % 1000 == 0) {
+                time_point_type stop = chrono::high_resolution_clock::now();
+                auto sec = chrono::duration_cast<chrono::seconds>(stop - start).count();
+                std::cerr << res.size() << ";" << sec << std::endl;
+            }
+#endif
+            /*cout << "Add result" << endl;
+      for(const auto &dat : tuple){
+          cout << "{" << (uint64_t) dat.first << "=" << dat.second << "} ";
+      }
+      cout << endl;*/
+        } else {
+            var_type x_j = m_veo.next();
+            // cout << "Variable: " << (uint64_t) x_j << endl;
+            // cout << (uint64_t) x_j << endl;
+            vector<ltj_iter_type*>& itrs = m_var_to_iterators[x_j];
+            bool ok;
+            if (itrs.size() == 1 && itrs[0]->in_last_level()) {  // Lonely variables
+                // cout << "Seeking (last level)" << endl;
+                auto results = itrs[0]->seek_all(x_j);
+                // cout << "Results: " << results.size() << endl;
+                // cout << "Seek (last level): (" << (uint64_t) x_j << ": size=" <<
+                // results.size() << ")" <<endl;
+                for (const auto& c : results) {
+                    // 1. Adding result to tuple
+                    tuple[j] = {x_j, c};
+                    // 2. Going down in the trie by setting x_j = c (\mu(t_i) in paper)
+                    itrs[0]->down(x_j, c);
+                    m_veo.down();
+                    // 2. Search with the next variable x_{j+1}
+                    ok = search(j + 1, tuple, res, start, limit_results, timeout_seconds);
+                    if (!ok)
+                        return false;
+                    // 4. Going up in the trie by removing x_j = c
+                    itrs[0]->up(x_j);
+                    m_veo.up();
+                }
+            } else {
+                // TODO: Make stats optional
+                IntersectionStats stats;
+                stats.variable_id = x_j;
+                stats.depth = j;
+
+                // Collect list sizes from each iterator
+                for (ltj_iter_type* iter : itrs) {
+                    // Determine which state/variable this iterator represents
+                    state_type state = o;  // default
+                    if (iter->is_variable_subject(x_j)) {
+                        state = s;
+                    } else if (iter->is_variable_predicate(x_j)) {
+                        state = p;
+                    }
+                    stats.list_sizes.push_back(iter->children(state));
+                }
+
+                value_type c = seek(x_j);
+                // cout << "Seek (init): (" << (uint64_t) x_j << ": " << c << ")"
+                // <<endl;
+                while (c != 0) {  // If empty c=0
+                    // Count each result found
+                    stats.result_size++;
+
+                    // 1. Adding result to tuple
+                    tuple[j] = {x_j, c};
+                    // 2. Going down in the tries by setting x_j = c (\mu(t_i) in paper)
+                    for (ltj_iter_type* iter : itrs) {
+                        iter->down(x_j, c);
+                    }
+                    m_veo.down();
+                    // 3. Search with the next variable x_{j+1}
+                    ok = search(j + 1, tuple, res, start, limit_results, timeout_seconds);
+                    if (!ok)
+                        return false;
+                    // 4. Going up in the tries by removing x_j = c
+                    for (ltj_iter_type* iter : itrs) {
+                        iter->up(x_j);
+                    }
+                    m_veo.up();
+                    // 5. Next constant for x_j
+                    c = seek(x_j, c + 1);
+                    // cout << "Seek (bucle): (" << (uint64_t) x_j << ": " << c << ")"
+                    // <<endl;
+                }
+
+                // TODO: Make stats optional
+                stats.alternation_complexity = calculate_alternation_complexity(itrs, x_j);
+
+                // TODO: compute leapfrog_seeks (needs to be done in seek)
+                m_stats.push_back(stats);
+            }
+            m_veo.done();
+        }
+        return true;
+    };
+
+    /**
+   *
+   * @param x_j   Variable
+   * @param c     Constant. If it is unknown the value is -1
+   * @return      The next constant that matches the intersection between the
+   * triples of x_j. If the intersection is empty, it returns 0.
+   */
+
+    value_type seek(const var_type x_j, value_type c = -1) {
+        vector<ltj_iter_type*>& itrs = m_var_to_iterators[x_j];
+        value_type c_i, c_prev = 0, i = 0, n_ok = 0;
+
+        while (true) {
+            // Compute leap for each triple that contains x_j
+            // std::cout << "Leap of " << (::uint64_t) x_j << " in iterator: " << i <<
+            // std::endl;
+            if (c == -1) {
+                c_i = itrs[i]->leap(x_j);
+            } else {
+                c_i = itrs[i]->leap(x_j, c);
+            }
+            // std::cout << "Gets " << (::uint64_t) c_i << std::endl;
+            if (c_i == 0) {
+                for (auto& itr : itrs) {
+                    itr->leap_done();
+                }
+                return 0;  // Empty intersection
+            }
+            n_ok = (c_i == c_prev) ? n_ok + 1 : 1;
+            if (n_ok == itrs.size()) {
+                return c_i;
+            }
+            c = c_prev = c_i;
+            i = (i + 1 == itrs.size()) ? 0 : i + 1;
+        }
+        for (auto& itr : itrs) {
+            itr->leap_done();
+        }
+    }
+
+    void print_veo(unordered_map<uint8_t, string>& ht) {
+        cout << "veo: ";
+        for (uint64_t j = 0; j < m_veo.size(); ++j) {
+            cout << "?" << ht[m_veo.next()] << " ";
+        }
+        cout << endl;
+    }
+
+    void print_query(unordered_map<uint8_t, string>& ht) {
+        cout << "Query: " << endl;
+        for (size_type i = 0; i < m_ptr_triple_patterns->size(); ++i) {
+            m_ptr_triple_patterns->at(i).print(ht);
+            if (i < m_ptr_triple_patterns->size() - 1) {
+                cout << " . ";
+            }
+        }
+        cout << endl;
+    }
+
+    void print_results(vector<tuple_type>& res, unordered_map<uint8_t, string>& ht) {
+        cout << "Results: " << endl;
+        uint64_t i = 1;
+        for (tuple_type& tuple : res) {
+            cout << "[" << i << "]: ";
+            for (pair<var_type, value_type>& pair : tuple) {
+                cout << "?" << ht[pair.first] << "=" << pair.second << " ";
+            }
+            cout << endl;
+            ++i;
+        }
+    }
+};
+}  // namespace ltj
+
+#endif  // RING_LTJ_ALGORITHM_HASH_HPP

--- a/include/query/ltj_iterator_metatrie_hash.hpp
+++ b/include/query/ltj_iterator_metatrie_hash.hpp
@@ -181,6 +181,25 @@ class ltj_iterator_metatrie_hash {
         return cur_node;
     }
 
+    /**
+     * @brief Returns the effective trie for the current iterator state.
+     *
+     * Applies the partial-to-full trie switch when needed
+     * (`m_nfixed == 2 && m_status_i == 1`).
+     */
+    const typename index_scheme_type::trie_type* resolve_trie() const {
+        const auto* trie = m_ptr_index->get_trie(m_trie_i);
+        if (m_nfixed == 2 && m_status_i == 1) {
+            switch (m_trie_i) {
+                case 1: trie = m_ptr_index->get_trie(4); break;  // SOP -> OSP
+                case 3: trie = m_ptr_index->get_trie(0); break;  // PSO -> SPO
+                case 5: trie = m_ptr_index->get_trie(2); break;  // OPS -> POS
+                default: break;
+            }
+        }
+        return trie;
+    }
+
   public:
     /*
       Returns the key of the current position of the iterator
@@ -199,6 +218,16 @@ class ltj_iterator_metatrie_hash {
         return m_ptr_triple_pattern->term_o.is_variable && var == m_ptr_triple_pattern->term_o.value;
     }
     inline const bool is_empty() { return m_is_empty; }
+
+    /**
+     * True iff the current LOUDS node (same trie and parent() as leap/exists)
+     * has an MPHF overlay.
+     */
+    bool current_node_has_hash() const {
+        if (m_is_empty)
+            return false;
+        return resolve_trie()->node_has_hash(parent());
+    }
 
     inline size_type parent() const;
 
@@ -343,6 +372,7 @@ class ltj_iterator_metatrie_hash {
             return true;
         }
 
+        // TODO: duplicated from original iterator logic; keep behavior for now, deduplicate with resolve_trie().
         if (m_nfixed == 2 && m_status_i == 1) {
             switch (m_trie_i) {
                 case 1:
@@ -383,6 +413,7 @@ class ltj_iterator_metatrie_hash {
         choose_trie(state);
         const auto* trie = m_ptr_index->get_trie(m_trie_i);
 
+        // TODO: duplicated from original iterator logic; keep behavior for now, deduplicate with resolve_trie().
         if (m_nfixed == 2 && m_status_i == 1) {
             switch (m_trie_i) {
                 case 1:
@@ -451,6 +482,7 @@ class ltj_iterator_metatrie_hash {
             t_i = m_trie_i;  // Previously decided
             s_i = m_status_i;  // Previously decided
 
+            // TODO: duplicated from original iterator logic; keep behavior for now, deduplicate with resolve_trie().
             if (m_nfixed == 2 && m_status_i == 1) {
                 switch (m_trie_i) {
                     case 1:
@@ -514,6 +546,7 @@ class ltj_iterator_metatrie_hash {
 
     inline size_type subtree_size_fixed2() const {
         const auto* trie = m_ptr_index->get_trie(m_trie_i);
+        // TODO: duplicated from original iterator logic; keep behavior for now, deduplicate with resolve_trie().
         if (m_nfixed == 2 && m_status_i == 1) {
             switch (m_trie_i) {
                 case 1:
@@ -535,6 +568,7 @@ class ltj_iterator_metatrie_hash {
     std::vector<uint64_t> seek_all(var_type x_j) {
         std::vector<uint64_t> results;
         size_type t_i;
+        // TODO: duplicated from original iterator logic; keep behavior for now, deduplicate with resolve_trie().
         if (m_nfixed == 2 && m_status_i == 1) {
             switch (m_trie_i) {
                 case 1:

--- a/include/query/ltj_iterator_metatrie_hash.hpp
+++ b/include/query/ltj_iterator_metatrie_hash.hpp
@@ -1,0 +1,572 @@
+/*
+ * ltj_iterator.hpp
+ * Copyright (C) 2023 Author removed for double-blind evaluation
+ *
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LTJ_ITERATOR_METATRIE_HASH_HPP
+#define LTJ_ITERATOR_METATRIE_HASH_HPP
+
+#include <cltj_config.hpp>
+#include <cltj_utils.hpp>
+#include <string>
+#include <triple_pattern.hpp>
+#include <vector>
+
+#define VERBOSE 0
+
+namespace ltj {
+
+template <class index_scheme_t, class var_t, class cons_t>
+class ltj_iterator_metatrie_hash {
+  public:
+    typedef cons_t value_type;
+    typedef var_t var_type;
+    typedef index_scheme_t index_scheme_type;
+    typedef uint64_t size_type;
+
+    typedef struct {
+        std::array<size_type, 2> it;
+        size_type cnt;
+        size_type beg;
+        size_type end;
+    } level_data_type;
+    typedef std::array<level_data_type, 4> status_type;
+    typedef std::array<bool, 4> redo_array_type;
+    // std::vector<value_type> leap_result_type;
+
+  private:
+    const triple_pattern* m_ptr_triple_pattern;
+    index_scheme_type* m_ptr_index;  // TODO: should be const
+    // std::vector<std::string> m_orders = {"0 1 2", "0 2 1", "1 2 0", "1 0 2", "2
+    // 0 1", "2 1 0"};
+    //                                      SPO      SOP      POS      PSO     OSP
+    //                                      OPS
+    // Penso que con esto debería ser suficiente (mais parte do de Diego)
+    bool m_is_empty = false;
+    // std::array<cltj::compact_trie*, 6> m_tries;
+    size_type m_nfixed = 0;
+    std::array<state_type, 3> m_fixed;
+
+    std::array<size_type, 3> m_path_label;
+
+    size_type m_trie_i = 0;
+    size_type m_status_i = 0;
+    status_type m_status;
+    redo_array_type m_redo;
+
+    void copy(const ltj_iterator_metatrie_hash& o) {
+        m_ptr_triple_pattern = o.m_ptr_triple_pattern;
+        m_ptr_index = o.m_ptr_index;
+        m_nfixed = o.m_nfixed;
+        m_fixed = o.m_fixed;
+        m_is_empty = o.m_is_empty;
+        m_trie_i = o.m_trie_i;
+        m_status_i = o.m_status_i;
+        m_status = o.m_status;
+        m_redo = o.m_redo;
+        m_path_label = o.m_path_label;
+    }
+
+    void print_status() {
+        std::cout << "fixed: " << m_nfixed << std::endl;
+        for (int i = 0; i < m_status.size(); ++i) {
+            std::cout << "it0=" << m_status[i].it[0] << " it1=" << m_status[i].it[1]
+                      << " cnt=" << m_status[i].cnt << " beg=" << m_status[i].beg
+                      << " end=" << m_status[i].end << std::endl;
+        }
+    }
+
+    void print_redo() {
+        for (int i = 0; i < m_redo.size(); ++i) {
+            std::cout << m_redo[i] << " ";
+        }
+        std::cout << std::endl;
+    }
+
+    void print_path() {
+        std::cout << "Current path: ";
+        for (int i = 0; i < m_nfixed; i++)
+            std::cout << m_path_label[i] << " ";
+        std::cout << std::endl;
+    }
+
+    void process_constants() {
+        if (!m_ptr_triple_pattern->s_is_variable()) {
+            if (!exists(s, m_ptr_triple_pattern->term_s.value)) {
+                m_is_empty = true;
+                return;
+            }
+            m_path_label[m_nfixed] = m_ptr_triple_pattern->term_s.value;
+            down(s);
+        }
+
+        if (!m_ptr_triple_pattern->p_is_variable()) {
+            if (!exists(p, m_ptr_triple_pattern->term_p.value)) {
+                m_is_empty = true;
+                return;
+            }
+            m_path_label[m_nfixed] = m_ptr_triple_pattern->term_p.value;
+            down(p);
+        }
+
+        if (!m_ptr_triple_pattern->o_is_variable()) {
+            if (!exists(o, m_ptr_triple_pattern->term_o.value)) {
+                m_is_empty = true;
+                return;
+            }
+            m_path_label[m_nfixed] = m_ptr_triple_pattern->term_o.value;
+            down(o);
+        }
+    }
+
+    void choose_trie(state_type state) {
+        if (m_nfixed == 0) {
+            m_trie_i = 2 * state;
+            m_status_i = 0;
+        } else if (m_nfixed == 1) {
+            if (state == s) {  // Fix variables
+                m_trie_i = (m_fixed[m_nfixed - 1] == o) ? 4 : 3;
+                m_status_i = (m_fixed[m_nfixed - 1] == o) ? 0 : 1;
+            } else if (state == p) {
+                m_trie_i = (m_fixed[m_nfixed - 1] == s) ? 0 : 5;
+                m_status_i = (m_fixed[m_nfixed - 1] == s) ? 0 : 1;
+            } else {
+                m_trie_i = (m_fixed[m_nfixed - 1] == p) ? 2 : 1;
+                m_status_i = (m_fixed[m_nfixed - 1] == p) ? 0 : 1;
+            }
+        }
+    }
+
+    size_type trie_switch() {
+        size_type trie_aux;
+        switch (m_trie_i) {
+            case 1:
+                trie_aux = 4;  // switches SOP -> OSP
+                break;
+            case 3:
+                trie_aux = 0;  // switches PSO -> SPO
+                break;
+            case 5:
+                trie_aux = 2;  // switches OPS -> POS
+                break;
+        }
+
+        const auto* trie = m_ptr_index->get_trie(trie_aux);  // switches to the corresponding trie
+        // Now gets down using the labels of the current path, reversed
+        auto cnt = trie->root_degree();
+        size_type beg, end;
+        beg = trie->first_child(0);
+        end = beg + cnt - 1;
+        auto p = trie->binary_search_seek(m_path_label[m_nfixed - 1], beg, end);
+        size_type cur_node = trie->nodeselect(p.second);
+        cnt = trie->children(cur_node);
+        beg = trie->first_child(cur_node);
+        end = beg + cnt - 1;
+        p = trie->binary_search_seek(m_path_label[m_nfixed - 2], beg, end);
+        cur_node = trie->nodeselect(p.second);
+        return cur_node;
+    }
+
+  public:
+    /*
+      Returns the key of the current position of the iterator
+  */
+    const size_type& nfixed = m_nfixed;
+
+    inline bool is_variable_subject(var_type var) {
+        return m_ptr_triple_pattern->term_s.is_variable && var == m_ptr_triple_pattern->term_s.value;
+    }
+
+    inline bool is_variable_predicate(var_type var) {
+        return m_ptr_triple_pattern->term_p.is_variable && var == m_ptr_triple_pattern->term_p.value;
+    }
+
+    inline bool is_variable_object(var_type var) {
+        return m_ptr_triple_pattern->term_o.is_variable && var == m_ptr_triple_pattern->term_o.value;
+    }
+    inline const bool is_empty() { return m_is_empty; }
+
+    inline size_type parent() const;
+
+    ltj_iterator_metatrie_hash() = default;
+    ltj_iterator_metatrie_hash(const triple_pattern* triple, index_scheme_type* index) {
+        m_ptr_triple_pattern = triple;
+        m_ptr_index = index;
+
+        m_status[0].it[0] = 0;
+        m_status[0].it[1] = 0;
+        m_status[0].beg = 1;
+        m_status[0].end = 0;
+        m_status[0].cnt = 1;
+        // m_status[1][0].it = 2;
+        // m_status[1][0].last = 1;
+        m_redo[0] = true;
+        m_redo[1] = true;
+        m_redo[2] = true;
+        m_redo[3] = true;
+
+        process_constants();
+    }
+    /*
+  ~ltj_iterator(){
+      m_ptr_triple_pattern = nullptr;
+      m_ptr_index = nullptr;
+  }
+  */
+
+    const triple_pattern* get_triple_pattern() const { return m_ptr_triple_pattern; }
+    //! Copy constructor
+    ltj_iterator_metatrie_hash(const ltj_iterator_metatrie_hash& o) { copy(o); }
+
+    //! Move constructor
+    ltj_iterator_metatrie_hash(ltj_iterator_metatrie_hash&& o) { *this = std::move(o); }
+
+    //! Copy Operator=
+    ltj_iterator_metatrie_hash& operator=(const ltj_iterator_metatrie_hash& o) {
+        if (this != &o) {
+            copy(o);
+        }
+        return *this;
+    }
+
+    //! Move Operator=
+    ltj_iterator_metatrie_hash& operator=(ltj_iterator_metatrie_hash&& o) {
+        if (this != &o) {
+            m_ptr_triple_pattern = std::move(o.m_ptr_triple_pattern);
+            m_ptr_index = std::move(o.m_ptr_index);
+            m_nfixed = std::move(o.m_nfixed);
+            m_fixed = std::move(o.m_fixed);
+            m_is_empty = std::move(o.m_is_empty);
+            m_trie_i = std::move(o.m_trie_i);
+            m_status_i = std::move(o.m_status_i);
+            m_status = std::move(o.m_status);
+            m_redo = std::move(o.m_redo);
+            m_path_label = std::move(o.m_path_label);
+        }
+        return *this;
+    }
+
+    void swap(ltj_iterator_metatrie_hash& o) {
+        // m_bp.swap(bp_support.m_bp); use set_vector to set the supported
+        // bit_vector
+        std::swap(m_ptr_triple_pattern, o.m_ptr_triple_pattern);
+        std::swap(m_ptr_index, o.m_ptr_index);
+        std::swap(m_nfixed, o.m_nfixed);
+        std::swap(m_fixed, o.m_fixed);
+        std::swap(m_is_empty, o.m_is_empty);
+        std::swap(m_trie_i, o.m_trie_i);
+        std::swap(m_status_i, o.m_status_i);
+        std::swap(m_status, o.m_status);
+        std::swap(m_redo, o.m_redo);
+        std::swap(m_path_label, o.m_path_label);
+    }
+
+    void down(state_type state) {
+        ++m_nfixed;
+        m_fixed[m_nfixed - 1] = state;
+
+        if (m_nfixed == 1) {
+            const auto* trie = m_ptr_index->get_trie(m_trie_i);
+            auto pos = m_status[m_nfixed].beg;
+            m_status[m_nfixed].it[0] = trie->nodeselect(pos);
+            const auto* trie_aux = m_ptr_index->get_trie(m_trie_i + 1);
+            m_status[m_nfixed].it[1] =
+                trie_aux->nodeselect(m_status[m_nfixed].beg - 1);  // -1 as there is no root in this trie
+        } else if (m_nfixed == 2) {
+            if (!m_status_i) {
+                const auto* trie = m_ptr_index->get_trie(m_trie_i);
+                auto pos = m_status[m_nfixed].beg;
+                m_status[m_nfixed].it[m_status_i] = trie->nodeselect(pos);
+            } else {
+                // trie switching
+                size_type switch_node = trie_switch();
+                m_status[m_nfixed].it[m_status_i] = switch_node;
+            }
+        }
+    }
+
+    void leap_done() { m_redo[m_nfixed] = true; }
+
+    void down(var_type var, value_type c) {  // Go down in the trie
+        m_path_label[m_nfixed] = c;  // keep the current path label
+
+        state_type state;
+        if (is_variable_subject(var)) {
+            state = s;
+        } else if (is_variable_predicate(var)) {
+            state = p;
+        } else {
+            state = o;
+        }
+        down(state);
+    };
+
+    // Reverses the intervals and variable weights. Also resets the current value.
+    void up(var_type var) {  // Go up in the trie
+        --m_nfixed;
+    };
+
+    bool exists(state_type state, size_type c) {  // Return the minimum in the
+        // range
+
+        choose_trie(state);
+        const auto* trie = m_ptr_index->get_trie(m_trie_i);
+
+        if (m_nfixed == 1 && m_status_i == 1) {
+            // const auto* trie_aux = m_ptr_index->get_trie(m_trie_i-1);
+            size_type beg, end;
+            size_type node = trie->nodeselect(m_status[m_nfixed].beg - 1);
+            auto cnt = trie->children(node);
+            beg = trie->first_child(node);
+            end = beg + cnt - 1;
+            auto p = trie->binary_search_seek(c, beg, end);
+            if (p.second > end or p.first != c)
+                return false;
+            m_status[m_nfixed + 1].beg = p.second;
+            m_status[m_nfixed + 1].end = end;
+            m_status[m_nfixed + 1].cnt = cnt;
+            m_redo[m_nfixed] = false;
+            return true;
+        }
+
+        if (m_nfixed == 2 && m_status_i == 1) {
+            switch (m_trie_i) {
+                case 1:
+                    trie = m_ptr_index->get_trie(4);  // switches SOP -> OSP
+                    break;
+                case 3:
+                    trie = m_ptr_index->get_trie(0);  // switches PSO -> SPO
+                    break;
+                case 5:
+                    trie = m_ptr_index->get_trie(2);  // switches OPS -> POS
+                    break;
+            }
+        }
+
+        size_type beg, end;
+        auto cnt = trie->children(parent());
+        beg = trie->first_child(parent());
+        end = beg + cnt - 1;
+        auto p = trie->binary_search_seek(c, beg, end);
+        if (p.second > end or p.first != c)
+            return false;
+        m_status[m_nfixed + 1].beg = p.second;
+        m_status[m_nfixed + 1].end = end;
+        m_status[m_nfixed + 1].cnt = cnt;
+        m_redo[m_nfixed] = false;
+        return true;
+    }
+
+    value_type leap(var_type var, size_type c = -1ULL) {  // Return the minimum in the range
+        // If c=-1 we need to get the minimum value for the current level.
+
+        state_type state = o;
+        if (is_variable_subject(var)) {
+            state = s;
+        } else if (is_variable_predicate(var)) {
+            state = p;
+        }
+        choose_trie(state);
+        const auto* trie = m_ptr_index->get_trie(m_trie_i);
+
+        if (m_nfixed == 2 && m_status_i == 1) {
+            switch (m_trie_i) {
+                case 1:
+                    trie = m_ptr_index->get_trie(4);  // switches SOP -> OSP
+                    break;
+                case 3:
+                    trie = m_ptr_index->get_trie(0);  // switches PSO -> SPO
+                    break;
+                case 5:
+                    trie = m_ptr_index->get_trie(2);  // switches OPS -> POS
+                    break;
+            }
+        }
+
+        size_type beg, end;
+        // std::cout << "Leap redo n_fixed:" << m_nfixed << std::endl;
+        // print_redo();
+        if (m_redo[m_nfixed]) {  // First time of leap
+            auto cnt = trie->children(parent());
+            beg = trie->first_child(parent());
+            end = beg + cnt - 1;
+            m_status[m_nfixed + 1].beg = beg;
+            m_status[m_nfixed + 1].end = end;
+            // m_status[m_nfixed+1].it[0] = m_status[m_nfixed+1].it[1] = it;
+            m_status[m_nfixed + 1].cnt = cnt;
+            m_redo[m_nfixed] = false;
+        } else {
+            // std::cout << "Current: " << current() << std::endl;
+            beg = m_status[m_nfixed + 1].beg;
+            end = m_status[m_nfixed + 1].end;
+        }
+        size_type value;
+        if (c == -1ULL) {
+            value = trie->seq[beg];
+            m_status[m_nfixed + 1].beg = beg;  // First position in the sequence
+        } else {
+            const auto p = trie->binary_search_seek(c, beg, end);
+            if (p.second > end)
+                return 0;
+            value = p.first;
+            m_status[m_nfixed + 1].beg = p.second;  // Position of the first value gt c
+        }
+
+        // print_status();
+        return value;
+    }
+
+    bool in_last_level() { return m_nfixed == 2; }
+
+    inline size_type children(state_type state) const {
+        size_type t_i, s_i = 0;
+        if (m_nfixed == 0) {
+            t_i = 2 * state;
+        } else if (m_nfixed == 1) {
+            if (state == s) {  // Fix variables
+                t_i = (m_fixed[m_nfixed - 1] == o) ? 4 : 3;
+                s_i = (m_fixed[m_nfixed - 1] == o) ? 0 : 1;
+            } else if (state == p) {
+                t_i = (m_fixed[m_nfixed - 1] == s) ? 0 : 5;
+                s_i = (m_fixed[m_nfixed - 1] == s) ? 0 : 1;
+            } else {
+                t_i = (m_fixed[m_nfixed - 1] == p) ? 2 : 1;
+                s_i = (m_fixed[m_nfixed - 1] == p) ? 0 : 1;
+            }
+        } else {
+            t_i = m_trie_i;  // Previously decided
+            s_i = m_status_i;  // Previously decided
+
+            if (m_nfixed == 2 && m_status_i == 1) {
+                switch (m_trie_i) {
+                    case 1:
+                        t_i = 4;  // switches SOP -> OSP
+                        break;
+                    case 3:
+                        t_i = 0;  // switches PSO -> SPO
+                        break;
+                    case 5:
+                        t_i = 2;  // switches OPS -> POS
+                        break;
+                }
+            }
+        }
+        auto trie = m_ptr_index->get_trie(t_i);
+        auto it = m_status[m_nfixed].it[s_i];
+        return trie->children(it);
+    }
+
+    inline size_type subtree_size_fixed1(state_type state) const {
+        size_type t_i, s_i;
+        if (state == s) {  // Fix variables
+            t_i = (m_fixed[m_nfixed - 1] == o) ? 4 : 3;
+            s_i = (m_fixed[m_nfixed - 1] == o) ? 0 : 1;
+        } else if (state == p) {
+            t_i = (m_fixed[m_nfixed - 1] == s) ? 0 : 5;
+            s_i = (m_fixed[m_nfixed - 1] == s) ? 0 : 1;
+        } else {
+            t_i = (m_fixed[m_nfixed - 1] == p) ? 2 : 1;
+            s_i = (m_fixed[m_nfixed - 1] == p) ? 0 : 1;
+        }
+
+        size_type leftmost_leaf, rightmost_leaf;
+        const auto* trie = m_ptr_index->get_trie(t_i);
+        if (s_i == 0) {
+            auto it = m_status[m_nfixed].it[s_i];
+            // Count children
+            auto cnt = trie->children(it);
+            // Leftmost
+            auto first = trie->child(it, 1);
+            leftmost_leaf = trie->first_child(first);
+            // Rightmost
+            it = trie->child(it, cnt);
+            cnt = trie->children(it);
+            rightmost_leaf = trie->first_child(it) + cnt - 1;
+        } else {
+            const auto* trie_aux = m_ptr_index->get_trie(t_i - 1);
+            auto it = m_status[m_nfixed].it[0];
+            // Count children
+            auto cnt = trie_aux->children(it);
+            // Leftmost
+            auto first = trie_aux->child(it, 1);
+            leftmost_leaf = trie_aux->first_child(first);
+            // Rightmost
+            it = trie_aux->child(it, cnt);
+            cnt = trie_aux->children(it);
+            rightmost_leaf = trie_aux->first_child(it) + cnt - 1;
+        }
+        return rightmost_leaf - leftmost_leaf + 1;
+    }
+
+    inline size_type subtree_size_fixed2() const {
+        const auto* trie = m_ptr_index->get_trie(m_trie_i);
+        if (m_nfixed == 2 && m_status_i == 1) {
+            switch (m_trie_i) {
+                case 1:
+                    trie = m_ptr_index->get_trie(4);  // switches SOP -> OSP
+                    break;
+                case 3:
+                    trie = m_ptr_index->get_trie(0);  // switches PSO -> SPO
+                    break;
+                case 5:
+                    trie = m_ptr_index->get_trie(2);  // switches OPS -> POS
+                    break;
+            }
+        }
+
+        auto it = m_status[m_nfixed].it[m_status_i];
+        return trie->children(it);
+    }
+
+    std::vector<uint64_t> seek_all(var_type x_j) {
+        std::vector<uint64_t> results;
+        size_type t_i;
+        if (m_nfixed == 2 && m_status_i == 1) {
+            switch (m_trie_i) {
+                case 1:
+                    t_i = 4;  // switches SOP -> OSP
+                    break;
+                case 3:
+                    t_i = 0;  // switches PSO -> SPO
+                    break;
+                case 5:
+                    t_i = 2;  // switches OPS -> POS
+                    break;
+                default:
+                    t_i = m_trie_i;
+            }
+        } else
+            t_i = m_trie_i;
+
+        const auto* trie = m_ptr_index->get_trie(t_i);
+        uint32_t cnt = trie->children(parent());
+        size_type beg = trie->first_child(parent());
+        for (auto i = beg; i < beg + cnt; ++i) {
+            results.emplace_back(trie->seq[i]);
+        }
+        return results;
+    }
+};
+
+template <class index_scheme_t, class var_t, class cons_t>
+uint64_t ltj_iterator_metatrie_hash<index_scheme_t, var_t, cons_t>::parent() const {
+    return m_status[m_nfixed].it[m_status_i];
+}
+
+}  // namespace ltj
+
+#endif  // LTJ_ITERATOR_METATRIE_HASH_HPP

--- a/include/query/ltj_iterator_metatrie_hash.hpp
+++ b/include/query/ltj_iterator_metatrie_hash.hpp
@@ -191,10 +191,17 @@ class ltj_iterator_metatrie_hash {
         const auto* trie = m_ptr_index->get_trie(m_trie_i);
         if (m_nfixed == 2 && m_status_i == 1) {
             switch (m_trie_i) {
-                case 1: trie = m_ptr_index->get_trie(4); break;  // SOP -> OSP
-                case 3: trie = m_ptr_index->get_trie(0); break;  // PSO -> SPO
-                case 5: trie = m_ptr_index->get_trie(2); break;  // OPS -> POS
-                default: break;
+                case 1:
+                    trie = m_ptr_index->get_trie(4);
+                    break;  // SOP -> OSP
+                case 3:
+                    trie = m_ptr_index->get_trie(0);
+                    break;  // PSO -> SPO
+                case 5:
+                    trie = m_ptr_index->get_trie(2);
+                    break;  // OPS -> POS
+                default:
+                    break;
             }
         }
         return trie;
@@ -227,6 +234,22 @@ class ltj_iterator_metatrie_hash {
         if (m_is_empty)
             return false;
         return resolve_trie()->node_has_hash(parent());
+    }
+
+    /**
+     * @brief O(1) membership check via the MPHF overlay of the current node.
+     *
+     * Resolves which trie to use for @p var (same logic as leap/exists),
+     * then delegates to the trie's hash_contains(parent(), key).
+     */
+    bool hash_contains(var_type var, value_type key) {
+        state_type state = o;
+        if (is_variable_subject(var))
+            state = s;
+        else if (is_variable_predicate(var))
+            state = p;
+        choose_trie(state);
+        return resolve_trie()->hash_contains(parent(), key);
     }
 
     inline size_type parent() const;

--- a/include/query/ltj_iterator_metatrie_hash.hpp
+++ b/include/query/ltj_iterator_metatrie_hash.hpp
@@ -252,6 +252,20 @@ class ltj_iterator_metatrie_hash {
         return resolve_trie()->hash_contains(parent(), key);
     }
 
+    /**
+     * @brief Returns the m_seq index range [beg, end) for children of the current node.
+     *
+     * The algorithm scans trie->seq[beg..end) to enumerate all children
+     * of the smallest list during hashing intersection.
+     */
+    std::pair<size_type, size_type> children_range() const {
+        const auto* trie = resolve_trie();
+        size_type node = parent();
+        size_type count = trie->children(node);
+        size_type beg = trie->first_child(node);
+        return {beg, beg + count};
+    }
+
     inline size_type parent() const;
 
     ltj_iterator_metatrie_hash() = default;

--- a/include/query/ltj_iterator_metatrie_hash.hpp
+++ b/include/query/ltj_iterator_metatrie_hash.hpp
@@ -227,12 +227,19 @@ class ltj_iterator_metatrie_hash {
     inline const bool is_empty() { return m_is_empty; }
 
     /**
-     * True iff the current LOUDS node (same trie and parent() as leap/exists)
-     * has an MPHF overlay.
+     * True iff the current LOUDS node for @p var has an MPHF overlay.
+     * Calls choose_trie internally so that resolve_trie()/parent() point
+     * to the correct trie for the given variable.
      */
-    bool current_node_has_hash() const {
+    bool current_node_has_hash(var_type var) {
         if (m_is_empty)
             return false;
+        state_type state = o;
+        if (is_variable_subject(var))
+            state = s;
+        else if (is_variable_predicate(var))
+            state = p;
+        choose_trie(state);
         return resolve_trie()->node_has_hash(parent());
     }
 
@@ -257,6 +264,7 @@ class ltj_iterator_metatrie_hash {
      *
      * The algorithm scans trie->seq[beg..end) to enumerate all children
      * of the smallest list during hashing intersection.
+     * Assumes the trie has been selected (e.g. via current_node_has_hash).
      */
     std::pair<size_type, size_type> children_range() const {
         const auto* trie = resolve_trie();
@@ -264,6 +272,16 @@ class ltj_iterator_metatrie_hash {
         size_type count = trie->children(node);
         size_type beg = trie->first_child(node);
         return {beg, beg + count};
+    }
+
+    /**
+     * @brief Returns the key stored at position @p pos in the active trie's m_seq.
+     *
+     * Used to scan children sequentially without allocating a vector.
+     * Assumes the trie has been selected (e.g. via current_node_has_hash).
+     */
+    value_type child_value_at(size_type pos) const {
+        return resolve_trie()->seq[pos];
     }
 
     inline size_type parent() const;

--- a/src/bench/bench-query-hcltj.cpp
+++ b/src/bench/bench-query-hcltj.cpp
@@ -1,0 +1,132 @@
+/*
+ * query-index.cpp
+ * Copyright (C) 2020 Author removed for double-blind evaluation
+ *
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <index/cltj_index_metatrie.hpp>
+#include <iostream>
+#include <query/ltj_algorithm_hash.hpp>
+#include <triple_pattern.hpp>
+#include <util/file_util.hpp>
+#include <util/time_util.hpp>
+#include <utility>
+
+using namespace std;
+
+// #include<chrono>
+// #include<ctime>
+
+using namespace ::util::time;
+
+template <class index_scheme_type, class trait_type>
+void query(
+    const std::string &file,
+    const std::string &queries,
+    const uint64_t limit,
+    const uint64_t timeout
+) {
+  vector<string> dummy_queries;
+  bool result = ::util::file::get_file_content(queries, dummy_queries);
+
+  index_scheme_type graph;
+  sdsl::load_from_file(graph, file);
+
+  std::cout << "Index loaded: " << sdsl::size_in_bytes(graph) << " bytes."
+            << std::endl;
+
+  std::ifstream ifs;
+  uint64_t nQ = 0;
+
+  //::util::time::usage::usage_type start, stop;
+  uint64_t total_elapsed_time;
+  uint64_t total_user_time;
+
+  if (result) {
+    int count = 1;
+    for (string &query_string : dummy_queries) {
+      // vector<Term*> terms_created;
+      // vector<Triple*> query;
+      std::vector<ltj::triple_pattern> query =
+          ::util::rdf::ids::get_query(query_string);
+
+      typedef ltj::ltj_iterator_metatrie_hash<index_scheme_type, uint8_t, uint64_t>
+          iterator_type;
+#if ADAPTIVE
+      typedef ltj::ltj_algorithm_hash<
+          iterator_type, ltj::veo::veo_adaptive<iterator_type, trait_type>>
+          algorithm_type;
+
+#else
+      typedef ltj::ltj_algorithm_hash<
+          iterator_type, ltj::veo::veo_simple<iterator_type, trait_type>>
+          algorithm_type;
+#endif
+      typedef ::util::results_collector<typename algorithm_type::tuple_type>
+          results_type;
+      results_type res;
+
+      auto start = std::chrono::high_resolution_clock::now();
+      algorithm_type ltj(&query, &graph);
+      ltj.join(res, limit, timeout);
+      auto stop = std::chrono::high_resolution_clock::now();
+      auto time =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start)
+              .count();
+      cout << nQ << ";" << res.size() << ";" << time << endl;
+      nQ++;
+
+      // cout << std::chrono::duration_cast<std::chrono::nanoseconds> (end -
+      // begin).count() << std::endl;
+
+      // cout << "RESULTS QUERY " << count << ": " << number_of_results << endl;
+      count += 1;
+    }
+  }
+}
+
+int main(int argc, char *argv[]) {
+  // typedef ring::c_ring ring_type;
+  if (argc < 5) {
+    std::cout << "Usage: " << argv[0]
+              << " <index> <queries> <limit> <type> [timeout]" << std::endl;
+    return 0;
+  }
+
+  std::string index = argv[1];
+  std::string queries = argv[2];
+  uint64_t limit = std::atoll(argv[3]);
+  std::string type = argv[4];
+  uint64_t timeout = 600; // in serconds
+  if (argc > 5) {
+    timeout = std::atoll(argv[5]);
+  }
+
+  if (type == "normal") {
+    query<cltj::compact_ltj_metatrie_hash, ltj::util::trait_distinct>(
+        index, queries, limit, timeout
+    );
+  } else if (type == "star") {
+    query<cltj::compact_ltj_metatrie_hash, ltj::util::trait_size>(
+        index, queries, limit, timeout
+    );
+  } else {
+    std::cout << "Type of index: " << type << " is not supported." << std::endl;
+  }
+
+  return 0;
+}

--- a/src/bench/build-hcltj.cpp
+++ b/src/bench/build-hcltj.cpp
@@ -1,0 +1,56 @@
+#include <index/cltj_index_metatrie.hpp>
+#include <iostream>
+
+using namespace std;
+
+using namespace std::chrono;
+using timer = std::chrono::high_resolution_clock;
+
+int main(int argc, char** argv) {
+    try {
+        if (argc != 2) {
+            cout << argv[0] << " <dataset>" << endl;
+            return 0;
+        }
+
+        std::string dataset = argv[1];
+        std::string index_name = dataset + ".hcltj";
+        vector<cltj::spo_triple> D;
+
+        std::ifstream ifs(dataset);
+        uint32_t s, p, o;
+        cltj::spo_triple spo;
+        do {
+            ifs >> s >> p >> o;
+            if (ifs.fail())
+                break;
+            spo[0] = s;
+            spo[1] = p;
+            spo[2] = o;
+            D.emplace_back(spo);
+        } while (!ifs.eof());
+
+        std::cout << "D.size()=" << D.size() << std::endl;
+        D.shrink_to_fit();
+        std::cout << "Dataset: " << 3 * D.size() * sizeof(::uint32_t) << " bytes." << std::endl;
+        // sdsl::memory_monitor::start();
+
+        auto start = timer::now();
+        cltj::compact_ltj_metatrie_hash index(D);
+        auto stop = timer::now();
+
+        // sdsl::memory_monitor::stop();
+
+        sdsl::store_to_file(index, index_name);
+
+        cout << "Index saved" << endl;
+        cout << duration_cast<seconds>(stop - start).count() << " seconds." << endl;
+        cout << sdsl::memory_monitor::peak() << " bytes." << endl;
+        // ti.indexNewTable(file_name);
+
+        // ind.save();
+    } catch (const char* msg) {
+        cerr << msg << endl;
+    }
+    return 0;
+}

--- a/src/bench/build-hcltj.cpp
+++ b/src/bench/build-hcltj.cpp
@@ -1,56 +1,60 @@
+#include <CLI11.hpp>
 #include <index/cltj_index_metatrie.hpp>
 #include <iostream>
-
-using namespace std;
 
 using namespace std::chrono;
 using timer = std::chrono::high_resolution_clock;
 
 int main(int argc, char** argv) {
-    try {
-        if (argc != 2) {
-            cout << argv[0] << " <dataset>" << endl;
-            return 0;
-        }
+    CLI::App app{"Build H-CLTJ index (metatrie + MPHF hash overlay)"};
+    std::string dataset;
+    uint32_t threshold = 1000;
+    app.add_option("dataset", dataset, "Input dataset file")->required();
+    app.add_option("-t,--threshold", threshold, "Min children to hash a node (default: 1000)");
+    CLI11_PARSE(app, argc, argv);
 
-        std::string dataset = argv[1];
+    try {
         std::string index_name = dataset + ".hcltj";
-        vector<cltj::spo_triple> D;
+        std::vector<cltj::spo_triple> D;
 
         std::ifstream ifs(dataset);
         uint32_t s, p, o;
         cltj::spo_triple spo;
         do {
             ifs >> s >> p >> o;
-            if (ifs.fail())
-                break;
-            spo[0] = s;
-            spo[1] = p;
-            spo[2] = o;
+            if (ifs.fail()) break;
+            spo[0] = s; spo[1] = p; spo[2] = o;
             D.emplace_back(spo);
         } while (!ifs.eof());
 
         std::cout << "D.size()=" << D.size() << std::endl;
         D.shrink_to_fit();
-        std::cout << "Dataset: " << 3 * D.size() * sizeof(::uint32_t) << " bytes." << std::endl;
-        // sdsl::memory_monitor::start();
+        std::cout << "Dataset: " << 3 * D.size() * sizeof(uint32_t) << " bytes." << std::endl;
 
         auto start = timer::now();
         cltj::compact_ltj_metatrie_hash index(D);
         auto stop = timer::now();
+        std::cout << "Trie build: " << duration_cast<seconds>(stop - start).count() << "s" << std::endl;
 
-        // sdsl::memory_monitor::stop();
+        std::cout << "Building hash overlay (threshold=" << threshold << ")..." << std::endl;
+        start = timer::now();
+        uint32_t total_mphfs = 0;
+        for (int i = 0; i < 6; i++) {
+            index.get_trie(i)->build_hash_overlay(threshold);
+            uint32_t n = static_cast<uint32_t>(index.get_trie(i)->mphf_count());
+            std::cout << "  trie " << i << ": " << n << " MPHFs" << std::endl;
+            total_mphfs += n;
+        }
+        stop = timer::now();
+        std::cout << "Hash overlay: " << total_mphfs << " MPHFs total, "
+                  << duration_cast<seconds>(stop - start).count() << "s" << std::endl;
 
         sdsl::store_to_file(index, index_name);
+        std::cout << "Index saved to " << index_name << std::endl;
+        std::cout << sdsl::memory_monitor::peak() << " bytes peak." << std::endl;
 
-        cout << "Index saved" << endl;
-        cout << duration_cast<seconds>(stop - start).count() << " seconds." << endl;
-        cout << sdsl::memory_monitor::peak() << " bytes." << endl;
-        // ti.indexNewTable(file_name);
-
-        // ind.save();
     } catch (const char* msg) {
-        cerr << msg << endl;
+        std::cerr << msg << std::endl;
     }
     return 0;
 }

--- a/src/bench/dump-trie-hcltj.cpp
+++ b/src/bench/dump-trie-hcltj.cpp
@@ -11,10 +11,10 @@ const char* trie_names[] = {"SPO", "SOP", "POS", "PSO", "OSP", "OPS"};
 void write_csv(const string& path,
                const vector<cltj::compact_metatrie_hash::NodeInfo>& nodes) {
     ofstream out(path);
-    out << "node,parent,depth,key,n_children\n";
+    out << "parent,depth,key,n_children,is_leaf\n";
     for (auto& n : nodes)
-        out << n.node << "," << n.parent << "," << n.depth << ","
-            << n.key << "," << n.n_children << "\n";
+        out << n.parent << "," << n.depth << ","
+            << n.key << "," << n.n_children << "," << (n.is_leaf ? 1 : 0) << "\n";
 }
 
 int main(int argc, char** argv) {

--- a/src/bench/dump-trie-hcltj.cpp
+++ b/src/bench/dump-trie-hcltj.cpp
@@ -1,0 +1,45 @@
+#include <index/cltj_index_metatrie.hpp>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include "CLI11.hpp"
+
+using namespace std;
+
+const char* trie_names[] = {"SPO", "SOP", "POS", "PSO", "OSP", "OPS"};
+
+void write_csv(const string& path,
+               const vector<cltj::compact_metatrie_hash::NodeInfo>& nodes) {
+    ofstream out(path);
+    out << "node,parent,depth,key,n_children\n";
+    for (auto& n : nodes)
+        out << n.node << "," << n.parent << "," << n.depth << ","
+            << n.key << "," << n.n_children << "\n";
+}
+
+int main(int argc, char** argv) {
+    CLI::App app{"Dump per-node trie structure from an H-CLTJ index"};
+    string index_file;
+    string outdir;
+    app.add_option("index", index_file, "Path to .hcltj index file")->required();
+    app.add_option("--outdir", outdir, "Directory to save per-trie CSV files")->required();
+    CLI11_PARSE(app, argc, argv);
+
+    cout << "Loading index from " << index_file << " ..." << endl;
+    cltj::compact_ltj_metatrie_hash index;
+    sdsl::load_from_file(index, index_file);
+    cout << "Index loaded (" << sdsl::size_in_bytes(index) << " bytes)" << endl;
+
+    system(("mkdir -p " + outdir).c_str());
+
+    for (int t = 0; t < 6; t++) {
+        auto* trie = index.get_trie(t);
+        auto nodes = trie->dump_nodes();
+        string csv_path = outdir + "/trie_" + to_string(t) + "_" + trie_names[t] + "_nodes.csv";
+        write_csv(csv_path, nodes);
+        cout << "Trie " << t << " (" << trie_names[t] << "): "
+             << nodes.size() << " nodes -> " << csv_path << endl;
+    }
+
+    return 0;
+}

--- a/src/bench/stats-hcltj.cpp
+++ b/src/bench/stats-hcltj.cpp
@@ -1,0 +1,73 @@
+#include <index/cltj_index_metatrie.hpp>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <numeric>
+#include "CLI11.hpp"
+
+using namespace std;
+
+const char* trie_names[] = {"SPO", "SOP", "POS", "PSO", "OSP", "OPS"};
+
+void print_summary(int trie_id, const map<uint64_t, uint64_t>& hist) {
+    uint64_t total_nodes = 0;
+    uint64_t max_children = 0;
+    uint64_t ge_100 = 0, ge_1000 = 0, ge_10000 = 0;
+
+    for (auto& [deg, count] : hist) {
+        total_nodes += count;
+        if (deg > max_children)
+            max_children = deg;
+        if (deg >= 100)
+            ge_100 += count;
+        if (deg >= 1000)
+            ge_1000 += count;
+        if (deg >= 10000)
+            ge_10000 += count;
+    }
+
+    cout << "Trie " << trie_id << " (" << trie_names[trie_id] << "): " << total_nodes << " nodes, "
+         << "max_children=" << max_children << ", "
+         << "nodes>=100: " << ge_100 << ", "
+         << "nodes>=1000: " << ge_1000 << ", "
+         << "nodes>=10000: " << ge_10000 << endl;
+}
+
+void write_csv(const string& path, const map<uint64_t, uint64_t>& hist) {
+    ofstream out(path);
+    out << "children,nodes\n";
+    for (auto& [deg, count] : hist)
+        out << deg << "," << count << "\n";
+}
+
+int main(int argc, char** argv) {
+    CLI::App app{"Children-per-node histograms for each trie in an H-CLTJ index"};
+    string index_file;
+    string outdir;
+    app.add_option("index", index_file, "Path to .hcltj index file")->required();
+    app.add_option("--outdir", outdir, "Directory to save per-trie CSV files");
+    CLI11_PARSE(app, argc, argv);
+
+    cout << "Loading index from " << index_file << " ..." << endl;
+    cltj::compact_ltj_metatrie_hash index;
+    sdsl::load_from_file(index, index_file);
+    cout << "Index loaded (" << sdsl::size_in_bytes(index) << " bytes)" << endl;
+    cout << endl;
+
+    if (!outdir.empty())
+        system(("mkdir -p " + outdir).c_str());
+
+    for (int t = 0; t < 6; t++) {
+        auto* trie = index.get_trie(t);
+        auto hist = trie->children_histogram();
+        print_summary(t, hist);
+
+        if (!outdir.empty()) {
+            string csv_path = outdir + "/trie_" + to_string(t) + "_" + trie_names[t] + ".csv";
+            write_csv(csv_path, hist);
+            cout << "  -> " << csv_path << endl;
+        }
+    }
+
+    return 0;
+}

--- a/src/test/hashing/test_mphf_move.cpp
+++ b/src/test/hashing/test_mphf_move.cpp
@@ -1,0 +1,64 @@
+// Tests that MPHF<GlGhStorage, QuotientKey> is movable and remains correct
+// after being stored in a std::vector (which requires move during reallocation).
+#include <hashing/mphf_bdz.hpp>
+#include <hashing/storage/glgh.hpp>
+#include <hashing/key_policies.hpp>
+#include <iostream>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+using MPHF_type = cltj::hashing::MPHF<cltj::hashing::GlGhStorage, cltj::hashing::policies::QuotientKey>;
+
+static std::vector<uint64_t> make_keys(size_t n, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::unordered_set<uint64_t> seen;
+    std::uniform_int_distribution<uint64_t> dist(1, n * 100);
+    while (seen.size() < n)
+        seen.insert(dist(rng));
+    return std::vector<uint64_t>(seen.begin(), seen.end());
+}
+
+int main() {
+    const size_t N = 5000;
+    auto keys = make_keys(N, 42);
+
+    // Build N/1000 small MPHFs and push them into a vector.
+    // The vector will reallocate and move elements internally.
+    std::vector<MPHF_type> mphfs;
+    std::vector<std::vector<uint64_t>> all_keys;
+
+    const size_t num_mphfs = 5;
+    const size_t keys_per_mphf = N / num_mphfs;
+
+    for (size_t i = 0; i < num_mphfs; ++i) {
+        std::vector<uint64_t> chunk(keys.begin() + i * keys_per_mphf, keys.begin() + (i + 1) * keys_per_mphf);
+        all_keys.push_back(chunk);
+
+        MPHF_type mphf;
+        bool ok = mphf.build(chunk);
+        if (!ok) {
+            std::cerr << "FAIL: build failed for chunk " << i << std::endl;
+            return 1;
+        }
+        mphfs.push_back(std::move(mphf));
+    }
+
+    // Verify each MPHF still works correctly after potential reallocation.
+    int failures = 0;
+    for (size_t i = 0; i < num_mphfs; ++i) {
+        for (uint64_t key : all_keys[i]) {
+            if (!mphfs[i].contains(key)) {
+                std::cerr << "FAIL: contains() returned false for key " << key << " in mphf " << i
+                          << " (after move into vector)" << std::endl;
+                ++failures;
+            }
+        }
+    }
+
+    if (failures == 0) {
+        std::cout << "PASS: all " << num_mphfs << " MPHFs correct after move into vector." << std::endl;
+        return 0;
+    }
+    return 1;
+}

--- a/src/test/hcltj/test_children_histogram.cpp
+++ b/src/test/hcltj/test_children_histogram.cpp
@@ -1,0 +1,70 @@
+// Verifies children_histogram() for all 6 tries of compact_ltj_metatrie_hash.
+// Expected values derived from data/data.txt.hcltj (11 triples, small dataset).
+// See journals/0016-embed-glgh-into-cltj/04-child-number-exp-results-small-dataset.md
+#include <index/cltj_index_metatrie.hpp>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+
+using histogram = std::map<uint64_t, uint64_t>;
+
+bool check(const std::string& label, const histogram& got, const histogram& expected) {
+    if (got == expected) {
+        std::cout << "  PASS " << label << std::endl;
+        return true;
+    }
+    std::cout << "  FAIL " << label << std::endl;
+    std::cout << "    expected: ";
+    for (auto& [k, v] : expected)
+        std::cout << "{" << k << ":" << v << "} ";
+    std::cout << std::endl;
+    std::cout << "    got:      ";
+    for (auto& [k, v] : got)
+        std::cout << "{" << k << ":" << v << "} ";
+    std::cout << std::endl;
+    return false;
+}
+
+int main(int argc, char** argv) {
+    std::string index_path = "data/data.txt.hcltj";
+    if (argc >= 2)
+        index_path = argv[1];
+
+    std::ifstream f(index_path);
+    if (!f.good()) {
+        std::cerr << "ERROR: index file not found: " << index_path << std::endl;
+        std::cerr << "  Build it first with: ./build/bench/build-hcltj data/data.txt" << std::endl;
+        return 1;
+    }
+    f.close();
+
+    cltj::compact_ltj_metatrie_hash index;
+    sdsl::load_from_file(index, index_path);
+
+    // Expected histograms from data/data.txt.hcltj
+    const histogram expected[6] = {
+        {{1, 10}, {2, 2}, {3, 1}, {4, 2}}, // SPO
+        {{1, 2}, {4, 2}}, // SOP
+        {{1, 15}, {2, 2}, {3, 1}, {7, 1}}, // POS
+        {{1, 5}, {2, 1}, {3, 1}}, // PSO
+        {{1, 13}, {2, 4}, {7, 1}}, // OSP
+        {{1, 3}, {2, 4}}, // OPS
+    };
+    const char* names[] = {"SPO", "SOP", "POS", "PSO", "OSP", "OPS"};
+
+    std::cout << "test_children_histogram (data/data.txt.hcltj)" << std::endl;
+    int failures = 0;
+    for (int t = 0; t < 6; t++) {
+        auto hist = index.get_trie(t)->children_histogram();
+        if (!check(names[t], hist, expected[t]))
+            failures++;
+    }
+
+    if (failures == 0)
+        std::cout << "ALL PASS" << std::endl;
+    else
+        std::cout << failures << " FAILED" << std::endl;
+
+    return failures > 0 ? 1 : 0;
+}

--- a/src/test/hcltj/test_hash_contains.cpp
+++ b/src/test/hcltj/test_hash_contains.cpp
@@ -1,0 +1,162 @@
+// Verifies node_has_hash() and hash_contains() on compact_metatrie_hash.
+// For each hashed node (>= threshold children): all children must return true,
+// and a non-child key must return false.
+// Runs with multiple thresholds {1, 2, 3} to cover different sets of hashed nodes.
+// Uses data/data.txt.hcltj (11 triples).
+#include <index/cltj_index_metatrie.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
+
+struct NodeData {
+    uint64_t node_pos;
+    uint64_t n_children;
+};
+
+struct TrieData {
+    const char* name;
+    std::vector<NodeData> all_nodes;  // every node with >= 1 child
+};
+
+int test_trie(cltj::compact_metatrie_hash* trie, const TrieData& data, uint32_t threshold) {
+    int failures = 0;
+
+    for (auto& [node_pos, n_children] : data.all_nodes) {
+        bool should_be_hashed = (n_children >= threshold);
+        bool is_hashed = trie->node_has_hash(node_pos);
+
+        if (should_be_hashed != is_hashed) {
+            std::cout << "  FAIL " << data.name << " node=" << node_pos << " node_has_hash()=" << is_hashed
+                      << " expected=" << should_be_hashed << std::endl;
+            failures++;
+            continue;
+        }
+
+        if (!is_hashed)
+            continue;
+
+        bool all_true = true;
+        for (uint64_t k = 0; k < n_children; k++) {
+            uint32_t key = static_cast<uint32_t>(trie->seq[node_pos + k]);
+            if (!trie->hash_contains(node_pos, key)) {
+                std::cout << "  FAIL " << data.name << " node=" << node_pos << " hash_contains(" << key
+                          << ") false (is a child)" << std::endl;
+                all_true = false;
+                failures++;
+            }
+        }
+        if (all_true)
+            std::cout << "  PASS " << data.name << " node=" << node_pos << " all " << n_children
+                      << " children return true" << std::endl;
+
+        uint32_t non_child = 999999;
+        if (trie->hash_contains(node_pos, non_child)) {
+            std::cout << "  FAIL " << data.name << " node=" << node_pos
+                      << " hash_contains(999999) true (not a child)" << std::endl;
+            failures++;
+        } else {
+            std::cout << "  PASS " << data.name << " node=" << node_pos
+                      << " non-child 999999 correctly returns false" << std::endl;
+        }
+    }
+    return failures;
+}
+
+int main(int argc, char** argv) {
+    std::string index_path = "data/data.txt.hcltj";
+    if (argc >= 2)
+        index_path = argv[1];
+
+    std::ifstream f(index_path);
+    if (!f.good()) {
+        std::cerr << "ERROR: index file not found: " << index_path << std::endl;
+        std::cerr << "  Build it with: ./build/bench/build-hcltj data/data.txt" << std::endl;
+        return 1;
+    }
+    f.close();
+
+    cltj::compact_ltj_metatrie_hash index;
+    sdsl::load_from_file(index, index_path);
+
+    // All nodes with >= 1 child, from journal 04
+    TrieData tries[6] = {
+        {"SPO",
+         {{0, 4},
+         {4, 3},
+         {7, 4},
+         {11, 2},
+         {13, 1},
+         {14, 1},
+         {15, 2},
+         {17, 1},
+         {18, 1},
+         {19, 1},
+         {20, 1},
+         {21, 1},
+         {22, 1},
+         {23, 1},
+         {24, 1}}                                                       },
+        {"SOP",                         {{0, 4}, {4, 4}, {8, 1}, {9, 1}}},
+        {"POS",
+         {{0, 7},
+         {7, 1},
+         {8, 2},
+         {10, 3},
+         {13, 2},
+         {15, 1},
+         {16, 1},
+         {17, 1},
+         {18, 1},
+         {19, 1},
+         {20, 1},
+         {21, 1},
+         {22, 1},
+         {23, 1},
+         {24, 1},
+         {25, 1},
+         {26, 1},
+         {27, 1},
+         {28, 1}}                                                       },
+        {"PSO", {{0, 1}, {1, 1}, {2, 3}, {5, 2}, {7, 1}, {8, 1}, {9, 1}}},
+        {"OSP",
+         {{0, 7},
+         {7, 1},
+         {8, 1},
+         {9, 1},
+         {10, 2},
+         {12, 1},
+         {13, 2},
+         {15, 2},
+         {17, 1},
+         {18, 1},
+         {19, 2},
+         {21, 1},
+         {22, 1},
+         {23, 1},
+         {24, 1},
+         {25, 1},
+         {26, 1},
+         {27, 1}}                                                       },
+        {"OPS", {{0, 1}, {1, 1}, {2, 2}, {4, 2}, {6, 1}, {7, 2}, {9, 2}}},
+    };
+
+    std::vector<uint32_t> thresholds = {1, 2, 3};
+    int total_failures = 0;
+
+    for (uint32_t threshold : thresholds) {
+        std::cout << "\n=== threshold=" << threshold << " ===" << std::endl;
+        for (int i = 0; i < 6; i++)
+            index.get_trie(i)->build_hash_overlay(threshold);
+
+        for (int t = 0; t < 6; t++)
+            total_failures += test_trie(index.get_trie(t), tries[t], threshold);
+    }
+
+    std::cout << std::endl;
+    if (total_failures == 0)
+        std::cout << "ALL PASS" << std::endl;
+    else
+        std::cout << total_failures << " FAILED" << std::endl;
+
+    return total_failures > 0 ? 1 : 0;
+}

--- a/src/test/hcltj/test_hcltj_correctness.cpp
+++ b/src/test/hcltj/test_hcltj_correctness.cpp
@@ -1,0 +1,127 @@
+// Correctness test: verifies that hcltj (hash path) produces the exact same
+// result tuples as xcltj (leapfrog only) for every query in a test set.
+// Uses data/data.txt.xcltj and data/data.txt.hcltj (11 triples, threshold=2).
+#include <algorithm>
+#include <index/cltj_index_metatrie.hpp>
+#include <iostream>
+#include <query/ltj_algorithm.hpp>
+#include <query/ltj_algorithm_hash.hpp>
+#include <query/ltj_iterator_metatrie.hpp>
+#include <query/ltj_iterator_metatrie_hash.hpp>
+#include <results/results_collector.hpp>
+#include <string>
+#include <util/rdf_util.hpp>
+#include <vector>
+#include <veo/veo_adaptive.hpp>
+
+using tuple_type = std::vector<std::pair<uint8_t, uint64_t>>;
+
+bool tuple_less(const tuple_type& a, const tuple_type& b) {
+    for (size_t i = 0; i < std::min(a.size(), b.size()); ++i) {
+        if (a[i].first != b[i].first)
+            return a[i].first < b[i].first;
+        if (a[i].second != b[i].second)
+            return a[i].second < b[i].second;
+    }
+    return a.size() < b.size();
+}
+
+template <class algorithm_type>
+std::vector<tuple_type> run_query(
+    const std::string& query_str, typename algorithm_type::index_scheme_type& index
+) {
+    auto query = ::util::rdf::ids::get_query(query_str);
+
+    ::util::results_collector<tuple_type> res;
+    algorithm_type ltj(&query, &index);
+    ltj.join(res, 0, 600);
+
+    std::vector<tuple_type> results;
+    uint64_t n = std::min(res.size(), (uint64_t)::util::results_collector<tuple_type>::buckets);
+    for (uint64_t i = 0; i < n; ++i)
+        results.push_back(res[i]);
+
+    for (auto& t : results)
+        std::sort(t.begin(), t.end());
+    std::sort(results.begin(), results.end(), tuple_less);
+    return results;
+}
+
+std::string tuple_to_string(const tuple_type& t) {
+    std::string s = "{";
+    for (size_t i = 0; i < t.size(); ++i) {
+        if (i > 0)
+            s += ", ";
+        s += "?" + std::to_string(t[i].first) + "=" + std::to_string(t[i].second);
+    }
+    return s + "}";
+}
+
+int main() {
+    using xcltj_index = cltj::compact_ltj_metatrie;
+    using xcltj_iter = ltj::ltj_iterator_metatrie<xcltj_index, uint8_t, uint64_t>;
+    using xcltj_algo =
+        ltj::ltj_algorithm<xcltj_iter, ltj::veo::veo_adaptive<xcltj_iter, ltj::util::trait_size>>;
+
+    using hcltj_index = cltj::compact_ltj_metatrie_hash;
+    using hcltj_iter = ltj::ltj_iterator_metatrie_hash<hcltj_index, uint8_t, uint64_t>;
+    using hcltj_algo =
+        ltj::ltj_algorithm_hash<hcltj_iter, ltj::veo::veo_adaptive<hcltj_iter, ltj::util::trait_size>>;
+
+    xcltj_index xcltj;
+    sdsl::load_from_file(xcltj, "data/data.txt.xcltj");
+
+    hcltj_index hcltj;
+    sdsl::load_from_file(hcltj, "data/data.txt.hcltj");
+
+    // Queries that exercise the intersection path (2+ iterators per variable).
+    // Triangle query (?v0 ?v1 ?v2 . ?v2 ?v1 ?v0) excluded: crashes on small
+    // datasets in BOTH xcltj and hcltj due to pre-existing bug in
+    // subtree_size_fixed1 (see journal 02).
+    std::vector<std::string> queries = {
+        "?x 9 ?y . ?x 8 ?z",
+        "?x 9 ?y . ?x 10 ?z",
+        "?s ?p 3",
+        "?x ?y 7 . ?x ?z 4",
+        "?x1 9 ?x2 . ?x2 11 ?x3 . ?x3 9 ?x4 . ?x1 10 ?x4",
+        "1 10 3",
+        "?a 9 ?b . ?c 9 ?b",
+    };
+
+    int failures = 0;
+    for (size_t q = 0; q < queries.size(); ++q) {
+        auto res_x = run_query<xcltj_algo>(queries[q], xcltj);
+        auto res_h = run_query<hcltj_algo>(queries[q], hcltj);
+
+        bool match = (res_x.size() == res_h.size());
+        if (match) {
+            for (size_t i = 0; i < res_x.size(); ++i) {
+                if (res_x[i] != res_h[i]) {
+                    match = false;
+                    break;
+                }
+            }
+        }
+
+        if (match) {
+            std::cout << "  PASS q" << q << " (" << res_x.size() << " results): " << queries[q] << std::endl;
+        } else {
+            std::cout << "  FAIL q" << q << ": " << queries[q] << std::endl;
+            std::cout << "    xcltj: " << res_x.size() << " results" << std::endl;
+            for (auto& t : res_x)
+                std::cout << "      " << tuple_to_string(t) << std::endl;
+            std::cout << "    hcltj: " << res_h.size() << " results" << std::endl;
+            for (auto& t : res_h)
+                std::cout << "      " << tuple_to_string(t) << std::endl;
+            failures++;
+        }
+    }
+
+    std::cout << std::endl;
+    if (failures == 0)
+        std::cout << "ALL PASS" << std::endl;
+    else
+        std::cout << failures << " FAILED" << std::endl;
+
+    return failures > 0 ? 1 : 0;
+}


### PR DESCRIPTION
This PR integrates a GlGh MPHF hash overlay into the CLTJ metatrie baseline. It implements the "scan-smallest + hash-contains" intersection scheme for large nodes.

## Architecture

The implementation copies and extends the three core layers of the metatrie baseline:

1. **Trie (`compact_metatrie_hash`)**: Extends `compact_metatrie` with a parallel hash overlay.
   - Nodes with `n_children >= threshold` are indexed with an `MPHF<GlGhStorage, QuotientKey>`.
   - `m_has_hash` bitvector tracks which nodes are hashed.
   - `m_seq` (the LOUDS children array) remains unchanged and redundant in this version; the MPHF is a pure overlay used only for `contains()`.
2. **Iterator (`ltj_iterator_metatrie_hash`)**: Wraps the trie's hash methods, respecting the trie-switch logic (partial to full trie transition).
3. **Algorithm (`ltj_algorithm_hash`)**: Adds the hashing intersection path to the leapfrog loop.

### Intersection Scheme

When intersecting variables, the algorithm checks the smallest list:

```text
intersect(A_1, ..., A_k):
    k_min = min{|A_i|}
    if A_kmin has hash (size >= threshold):
        // HASH PATH
        for x in A_kmin (sequential scan of m_seq):
            if all(x in H[A] for A in A_others):  // O(1) via MPHF
                yield x
    else:
        // LEAPFROG PATH
        leapfrog(A_1, ..., A_k) // existing binary search
```

*Note: By the intersection invariant, if the smallest list is >= threshold, all other lists participating in the intersection are guaranteed to be >= threshold as well, so they all have O(1) hash lookup available.*

## Threshold Selection & Tooling

To determine the threshold, some analysis tools were added:
- `stats-hcltj` (C++): Dumps `children` vs `nodes` histograms per trie.
- `children_histogram` (Python): Analyzes the CSVs to compute coverage (% of nodes/children hashed) at different thresholds.
- `dump-trie-hcltj` & `trie_viz`: Exports node structure and draws the metatrie as a tree to debug the build process and verify partial/full trie structures.

## Additions

- `build-hcltj`: New CLI to build the hashed index from a serialized metatrie.
- `hcltj-correctness`: End-to-end correctness test verifying the hash overlay produces identical query results to the baseline.
- Hash lookup helpers (`hash_contains`, `resolve_trie`, `children_range`) in the iterator.

## Status Note

This version implements the overlay as a pure time-optimization overhead (GlGh + Quotienting bits are added on top of `m_seq`). Compacting `m_seq` to remove redundant keys is left for later.

During the first runs on Wikidata, systematic peeling failures happened in the MPHF construction for some large nodes. There were already some reasons to believe that the peeling system had some issues, and this came to confirm that. In order to investigate this problem, some intrumentalization was necessary (as a follow up, so this PR can be closed, because it's large enough).