### PR TITLE
Ltj 19 sdsl submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/fastmod"]
 	path = lib/fastmod
 	url = https://github.com/lemire/fastmod
+[submodule "lib/sdsl-lite"]
+	path = lib/sdsl-lite
+	url = https://github.com/adriangbrandon/sdsl-lite.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ endif()
 # Options to control permissive mode and libc++ usage
 option(CLTJ_PERMISSIVE "Add -fpermissive to mimic legacy builds" ON)
 option(CLTJ_USE_LIBCXX "Force -stdlib=libc++ (needed mainly on macOS)" ON)
+option(CLTJ_USE_BUNDLED_SDSL "Build and link bundled lib/sdsl-lite submodule" ON)
+option(CLTJ_APPLY_BUNDLED_SDSL_PATCHES "Apply local compatibility patches to bundled lib/sdsl-lite" ON)
 option(CLTJ_COLLECT_QUERY_STATS "Collect intersection stats (disable for clean benchmarks)" ON)
 option(CLTJ_COLLECT_MPHF_BUILD_TRACE "Trace MPHF build per-node (JSONL output)" OFF)
 option(CLTJ_DUMP_MPHF_KEYS "Dump key sets for failed MPHF builds (binary)" OFF)
@@ -73,11 +75,49 @@ else()
     message(STATUS "CPU does NOT support SSE4.2")
 endif()
 
-include_directories(~/include
-                    ${CMAKE_HOME_DIRECTORY}/lib/hybridBV/include
-                    ${CMAKE_HOME_DIRECTORY}/include)
+if(CLTJ_USE_BUNDLED_SDSL)
+  if(CLTJ_APPLY_BUNDLED_SDSL_PATCHES)
+    find_program(GIT_EXECUTABLE git REQUIRED)
+    set(CLTJ_SDSL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/sdsl-lite)
+    set(CLTJ_SDSL_PATCH ${CMAKE_CURRENT_SOURCE_DIR}/third_party/patches/sdsl-louds-tree-swap.patch)
 
-link_directories(~/lib)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C ${CLTJ_SDSL_DIR} apply --check ${CLTJ_SDSL_PATCH}
+      RESULT_VARIABLE CLTJ_SDSL_PATCH_CAN_APPLY
+      OUTPUT_QUIET
+      ERROR_QUIET
+    )
+    if(CLTJ_SDSL_PATCH_CAN_APPLY EQUAL 0)
+      message(STATUS "Applying bundled sdsl-lite compatibility patch: sdsl-louds-tree-swap.patch")
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} -C ${CLTJ_SDSL_DIR} apply ${CLTJ_SDSL_PATCH}
+        COMMAND_ERROR_IS_FATAL ANY
+      )
+    else()
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} -C ${CLTJ_SDSL_DIR} apply --reverse --check ${CLTJ_SDSL_PATCH}
+        RESULT_VARIABLE CLTJ_SDSL_PATCH_ALREADY_APPLIED
+        OUTPUT_QUIET
+        ERROR_QUIET
+      )
+      if(CLTJ_SDSL_PATCH_ALREADY_APPLIED EQUAL 0)
+        message(STATUS "Bundled sdsl-lite compatibility patch already applied")
+      else()
+        message(FATAL_ERROR
+          "Bundled sdsl-lite does not match the expected patch state for "
+          "third_party/patches/sdsl-louds-tree-swap.patch"
+        )
+      endif()
+    endif()
+  endif()
+  add_subdirectory(lib/sdsl-lite EXCLUDE_FROM_ALL)
+else()
+  include_directories(~/include)
+  link_directories(~/lib)
+endif()
+
+include_directories(${CMAKE_HOME_DIRECTORY}/lib/hybridBV/include
+                    ${CMAKE_HOME_DIRECTORY}/include)
 add_subdirectory(lib/hybridBV)
 add_subdirectory(lib/pthash)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 option(CLTJ_PERMISSIVE "Add -fpermissive to mimic legacy builds" ON)
 option(CLTJ_USE_LIBCXX "Force -stdlib=libc++ (needed mainly on macOS)" ON)
 option(CLTJ_USE_BUNDLED_SDSL "Build and link bundled lib/sdsl-lite submodule" ON)
-option(CLTJ_APPLY_BUNDLED_SDSL_PATCHES "Apply local compatibility patches to bundled lib/sdsl-lite" ON)
 option(CLTJ_COLLECT_QUERY_STATS "Collect intersection stats (disable for clean benchmarks)" ON)
 option(CLTJ_COLLECT_MPHF_BUILD_TRACE "Trace MPHF build per-node (JSONL output)" OFF)
 option(CLTJ_DUMP_MPHF_KEYS "Dump key sets for failed MPHF builds (binary)" OFF)
@@ -76,40 +75,6 @@ else()
 endif()
 
 if(CLTJ_USE_BUNDLED_SDSL)
-  if(CLTJ_APPLY_BUNDLED_SDSL_PATCHES)
-    find_program(GIT_EXECUTABLE git REQUIRED)
-    set(CLTJ_SDSL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/sdsl-lite)
-    set(CLTJ_SDSL_PATCH ${CMAKE_CURRENT_SOURCE_DIR}/third_party/patches/sdsl-louds-tree-swap.patch)
-
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} -C ${CLTJ_SDSL_DIR} apply --check ${CLTJ_SDSL_PATCH}
-      RESULT_VARIABLE CLTJ_SDSL_PATCH_CAN_APPLY
-      OUTPUT_QUIET
-      ERROR_QUIET
-    )
-    if(CLTJ_SDSL_PATCH_CAN_APPLY EQUAL 0)
-      message(STATUS "Applying bundled sdsl-lite compatibility patch: sdsl-louds-tree-swap.patch")
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} -C ${CLTJ_SDSL_DIR} apply ${CLTJ_SDSL_PATCH}
-        COMMAND_ERROR_IS_FATAL ANY
-      )
-    else()
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} -C ${CLTJ_SDSL_DIR} apply --reverse --check ${CLTJ_SDSL_PATCH}
-        RESULT_VARIABLE CLTJ_SDSL_PATCH_ALREADY_APPLIED
-        OUTPUT_QUIET
-        ERROR_QUIET
-      )
-      if(CLTJ_SDSL_PATCH_ALREADY_APPLIED EQUAL 0)
-        message(STATUS "Bundled sdsl-lite compatibility patch already applied")
-      else()
-        message(FATAL_ERROR
-          "Bundled sdsl-lite does not match the expected patch state for "
-          "third_party/patches/sdsl-louds-tree-swap.patch"
-        )
-      endif()
-    endif()
-  endif()
   add_subdirectory(lib/sdsl-lite EXCLUDE_FROM_ALL)
 else()
   include_directories(~/include)

--- a/third_party/patches/sdsl-louds-tree-swap.patch
+++ b/third_party/patches/sdsl-louds-tree-swap.patch
@@ -1,0 +1,15 @@
+diff --git a/include/sdsl/louds_tree.hpp b/include/sdsl/louds_tree.hpp
+index 6d6d6e9..2149e34 100644
+--- a/include/sdsl/louds_tree.hpp
++++ b/include/sdsl/louds_tree.hpp
+@@ -179,8 +179,8 @@ class louds_tree
+ 
+         void swap(louds_tree& tree) {
+             m_bv.swap(tree.m_bv);
+-            util::swap_support(m_bv_select1, tree.m_select1, &m_bv, &(tree.m_bv));
+-            util::swap_support(m_bv_select0, tree.m_select0, &m_bv, &(tree.m_bv));
++            util::swap_support(m_bv_select1, tree.m_bv_select1, &m_bv, &(tree.m_bv));
++            util::swap_support(m_bv_select0, tree.m_bv_select0, &m_bv, &(tree.m_bv));
+         }
+ 
+         size_type serialize(std::ostream& out, structure_tree_node* v=nullptr, std::string name="")const {


### PR DESCRIPTION
This PR makes `cltj` reproducible with recursive submodules while keeping SDSL patching explicit and manual.

Changes included:
- Add bundled `sdsl-lite` as submodule (`lib/sdsl-lite`).
- Add local patch file (othersiwe it doesn't compile):
  - `third_party/patches/sdsl-louds-tree-swap.patch`

## Why

Goal: enable a clean server workflow where `git clone --recursive` brings all required code, including SDSL, without relying on preinstalled local SDSL in `~/include` / `~/lib`.

Found a build-breaking issue in `sdsl/louds_tree.hpp`:
- `swap()` references `tree.m_select1` / `tree.m_select0` (non-existent members).
- Correct members are `tree.m_bv_select1` / `tree.m_bv_select0`.

This breaks clean builds of bundled SDSL (`louds_tree.cpp`) unless patched.

## Patch details

`third_party/patches/sdsl-louds-tree-swap.patch` applies this minimal fix in `include/sdsl/louds_tree.hpp`:

- `tree.m_select1` -> `tree.m_bv_select1`
- `tree.m_select0` -> `tree.m_bv_select0`

## Manual recipe (intended workflow)

```bash
git clone --recursive <cltj-repo-url>
cd cltj

git -C lib/sdsl-lite apply third_party/patches/sdsl-louds-tree-swap.patch

cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
```
