### PR TITLE
LTJ-22 serialize MPHF coefficients instead of regenerating them on load

### DIFF
--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -32,7 +32,7 @@ namespace hashing {
  *   - used_pos_bytes : B bitvector marking used slots.
  *   - rank_bytes     : rank support over B.
  *   - q_bytes        : key payload (FullKey, QuotientKey, ...).
- *   - other_bytes    : serialized metadata (n, prime deltas, retry_count, n_peeled).
+ *   - other_bytes    : serialized metadata (n, prime deltas, retry_count, multipliers, biases, n_peeled).
  *   - fallback_bytes : fallback system residual array (sorted residual keys).
  */
 struct SizeBreakdown {
@@ -161,9 +161,11 @@ class MPHF {
         breakdown.used_pos_bytes = storage_breakdown.used_pos_bytes;
         breakdown.rank_bytes = storage_breakdown.rank_bytes;
         breakdown.q_bytes = key_policy_.size_in_bytes();
-        // Metadata: n (4) + 3×prime_deltas (3) + retry_count (1) + n_peeled (4) = 12 bytes
+        // Metadata: n (4) + 3×prime_deltas (3) + retry_count (1) + multipliers (24)
+        //           + biases (24) + n_peeled (4) = 60 bytes
         // Note: m_ and primes_ are not serialized (computed/reconstructed)
-        breakdown.other_bytes = sizeof(n_) + 3 * sizeof(uint8_t) + sizeof(retry_count_) + sizeof(n_peeled_);
+        breakdown.other_bytes = sizeof(n_) + 3 * sizeof(uint8_t) + sizeof(retry_count_) +
+            sizeof(multipliers_) + sizeof(biases_) + sizeof(n_peeled_);
         breakdown.fallback_bytes = sizeof(uint32_t)  // residual_count field
             + residual_keys_.size() * sizeof(uint32_t);
         return breakdown;
@@ -208,6 +210,15 @@ class MPHF {
         }
         written_bytes += sdsl::write_member(retry_count_, out, child, "retry_count_");
 
+        // Hash coefficients a_k, b_k.
+        for (int k = 0; k < 3; ++k) {
+            written_bytes +=
+                sdsl::write_member(multipliers_[k], out, child, "multiplier_" + std::to_string(k));
+        }
+        for (int k = 0; k < 3; ++k) {
+            written_bytes += sdsl::write_member(biases_[k], out, child, "bias_" + std::to_string(k));
+        }
+
         // KeyPolicy payload
         written_bytes += key_policy_.serialize(out, child, "key_policy_");
 
@@ -242,14 +253,20 @@ class MPHF {
         }
         sdsl::read_member(retry_count_, in);
 
+        // Hash coefficients a_k, b_k, stored directly (see serialize()).
+        for (int k = 0; k < 3; ++k) {
+            sdsl::read_member(multipliers_[k], in);
+        }
+        for (int k = 0; k < 3; ++k) {
+            sdsl::read_member(biases_[k], in);
+        }
+
         m_ = static_cast<uint32_t>(primes_[0] + primes_[1] + primes_[2]);
 
         // Rebuild derived hash state
         segment_starts_[0] = 0;
         segment_starts_[1] = primes_[0];
         segment_starts_[2] = primes_[0] + primes_[1];
-
-        regenerate_coefficients();
 
         // KeyPolicy only needs the hash parameters rebound before load().
         policies::KeyInitContext ctx{n_, primes_, multipliers_, biases_, segment_starts_, 0};
@@ -682,25 +699,6 @@ class MPHF {
     }
 
     // ========== HELPER FUNCTIONS ==========
-    /**
-     * @brief Regenerate multipliers and biases from retry_count using SplitMix64 mixer.
-     * Used during deserialization to avoid storing 48 bytes of coefficients.
-     */
-    void regenerate_coefficients() {
-        uint64_t final_seed = splitmix64(SEED ^ static_cast<uint64_t>(retry_count_));
-        std::mt19937_64 rng(final_seed);
-        for (int k = 0; k < 3; ++k) {
-            uint64_t p = primes_[static_cast<size_t>(k)];
-            std::uniform_int_distribution<uint64_t> distA(1, p - 1);
-            multipliers_[static_cast<size_t>(k)] = distA(rng);
-        }
-        for (int k = 0; k < 3; ++k) {
-            uint64_t p = primes_[static_cast<size_t>(k)];
-            std::uniform_int_distribution<uint64_t> distB(0, p - 1);
-            biases_[static_cast<size_t>(k)] = distB(rng);
-        }
-    }
-
     /**
      * @brief Compute hash function h_k(x) for k ∈ {0,1,2}
      * h_k(x) = d_k + ((a_k · x + b_k) mod r_k)

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -253,7 +253,7 @@ class MPHF {
         }
         sdsl::read_member(retry_count_, in);
 
-        // Hash coefficients a_k, b_k, stored directly (see serialize()).
+        // Hash coefficients a_k, b_k.
         for (int k = 0; k < 3; ++k) {
             sdsl::read_member(multipliers_[k], in);
         }

--- a/src/test/hashing/test_mphf.cpp
+++ b/src/test/hashing/test_mphf.cpp
@@ -112,7 +112,7 @@ TestResult run_test_case(size_t n) {
         for (size_t i = 0; i < negative_sample_size; ++i) {
             uint64_t non_key;
             do {
-                non_key = rng();
+                non_key = static_cast<uint32_t>(rng());  // premix32 domain: keys must fit in uint32_t
             } while (key_set.count(non_key));  // Ensure it's not actually a key
 
             if (mphf.contains(non_key)) {

--- a/src/test/hashing/test_mphf_serialization.cpp
+++ b/src/test/hashing/test_mphf_serialization.cpp
@@ -54,8 +54,9 @@ std::vector<uint64_t> synthesize_fallback_fixture(
     for (size_t i = indexed_keys.size() - residual_count; i < indexed_keys.size(); ++i) {
         uint64_t key = indexed_keys[i].second;
         residual_keys.push_back(key);
-        mphf.residual_keys_.push_back(static_cast<uint32_t>(cltj::hashing::premix32(static_cast<uint32_t>(key)
-        )));
+        mphf.residual_keys_.push_back(
+            static_cast<uint32_t>(cltj::hashing::premix32(static_cast<uint32_t>(key)))
+        );
     }
     std::sort(mphf.residual_keys_.begin(), mphf.residual_keys_.end());
     mphf.n_peeled_ = static_cast<uint32_t>(keys.size() - residual_count);
@@ -139,6 +140,12 @@ void test_roundtrip(
     std::cout << "  [OK] Metadata preserved: m=" << original_m << " n=" << original_n
               << " retries=" << original_retries << " n_peeled=" << original_n_peeled
               << " residual=" << original_n_residual << std::endl;
+
+    // 1b. Hash coefficients must be reloaded byte-for-byte
+    assert(mphf2.get_multipliers() == mphf1.get_multipliers() && "multipliers_ mismatch after load");
+    assert(mphf2.get_biases() == mphf1.get_biases() && "biases_ mismatch after load");
+    assert(mphf2.get_primes() == mphf1.get_primes() && "primes_ mismatch after load");
+    std::cout << "  [OK] Hash coefficients (multipliers, biases, primes) preserved" << std::endl;
 
     // 2. Check that all query() results match
     bool queries_match = true;


### PR DESCRIPTION
## What changed

- `MPHF::serialize()` now writes the hash coefficients (`multipliers_` and `biases_`, 48 bytes per MPHF) directly, and `load()` reads them back. `regenerate_coefficients()` is gone.
- `retry_count` and the delta-encoded primes are untouched.
- The serialized MPHF format changes, so existing `.hcltj` indexes have to be rebuilt.
- Also fixed a preexisting `test-mphf` bug: its false-positive probe drew non-keys from `mt19937_64` (full 64-bit values), which trip the premix32 uint32 domain assertion. The draw is now masked to uint32.

## Why

An earlier optimization (LTJ-12, #10) serialized only `retry_count` and rebuilt the coefficients on load by re-running `mt19937_64` once per MPHF. On the Wikidata index that's ~15,700 PRNG initializations on every load, and `std::uniform_int_distribution` isn't portable across standard libraries, so a serialized index wasn't portable between platforms. The space it saved (~0.7 MB total) wasn't worth either cost. Storing the coefficients reverts that: nothing is regenerated on load, and a built index is portable.

## Validation

- Full MPHF test suite passes locally; the serialization round-trip test now also checks that the coefficients reload byte-for-byte.
- Rebuilt the full Wikidata index (15,692 MPHFs) and ran `verify-mphf-hcltj`: ALL PASS, no false negatives or positives. The `mt19937` regeneration no longer appears in the load profile.