### PR TITLE
LTJ-23 refactor MPHF interface to uint32_t

### DIFF
--- a/include/hashing/key_dumper.hpp
+++ b/include/hashing/key_dumper.hpp
@@ -20,7 +20,7 @@ namespace hashing {
 // ============================================================
 
 constexpr char DUMP_MAGIC[4] = {'M', 'K', 'E', 'Y'};
-constexpr uint32_t DUMP_VERSION = 1;
+constexpr uint32_t DUMP_VERSION = 2;
 
 /**
  * @brief On-disk header for MPHF key dump files (40 bytes, little-endian).
@@ -33,7 +33,7 @@ constexpr uint32_t DUMP_VERSION = 1;
  *   [8]  node_pos  uint64
  *   [8]  n_keys    uint64
  *   [8]  checksum  uint64 (FNV-1a 64-bit over the key array bytes)
- *   [n*8] keys     uint64_t[]
+ *   [n*4] keys     uint32_t[]
  */
 struct KeyDumpHeader {
     char magic[4];  // DUMP_MAGIC
@@ -47,15 +47,15 @@ struct KeyDumpHeader {
 static_assert(sizeof(KeyDumpHeader) == 40, "KeyDumpHeader must be 40 bytes");
 
 /**
- * @brief FNV-1a 64-bit checksum over the raw bytes of a uint64_t array.
+ * @brief FNV-1a 64-bit checksum over the raw bytes of a uint32_t array.
  * Reference: http://www.isthe.com/chongo/tech/comp/fnv/  (fnv_64a_buf)
  */
-inline uint64_t fnv1a64(const std::vector<uint64_t>& keys) {
+inline uint64_t fnv1a64(const std::vector<uint32_t>& keys) {
     constexpr uint64_t basis = 14695981039346656037ULL;
     constexpr uint64_t prime = 1099511628211ULL;
     uint64_t h = basis;
     const uint8_t* data = reinterpret_cast<const uint8_t*>(keys.data());
-    for (size_t i = 0; i < keys.size() * sizeof(uint64_t); ++i) {
+    for (size_t i = 0; i < keys.size() * sizeof(uint32_t); ++i) {
         h ^= data[i];
         h *= prime;
     }
@@ -67,7 +67,7 @@ inline uint64_t fnv1a64(const std::vector<uint64_t>& keys) {
  * Sets magic, version, trie_id, pad, node_pos, n_keys, and checksum.
  */
 inline KeyDumpHeader make_dump_header(
-    uint32_t trie_id, uint64_t node_pos, const std::vector<uint64_t>& keys
+    uint32_t trie_id, uint64_t node_pos, const std::vector<uint32_t>& keys
 ) {
     KeyDumpHeader hdr{};
     hdr.magic[0] = DUMP_MAGIC[0];
@@ -88,7 +88,7 @@ inline KeyDumpHeader make_dump_header(
  * @return true on success, false on I/O error.
  */
 inline bool write_dump_file(
-    const std::string& path, const KeyDumpHeader& hdr, const std::vector<uint64_t>& keys
+    const std::string& path, const KeyDumpHeader& hdr, const std::vector<uint32_t>& keys
 ) {
     std::ofstream out(path, std::ios::binary | std::ios::trunc);
     if (!out)
@@ -96,7 +96,7 @@ inline bool write_dump_file(
     out.write(reinterpret_cast<const char*>(&hdr), sizeof(KeyDumpHeader));
     out.write(
         reinterpret_cast<const char*>(keys.data()),
-        static_cast<std::streamsize>(keys.size() * sizeof(uint64_t))
+        static_cast<std::streamsize>(keys.size() * sizeof(uint32_t))
     );
     return out.good();
 }
@@ -106,7 +106,7 @@ inline bool write_dump_file(
  * @return Empty string on success; human-readable error on failure.
  * On success, hdr and keys are populated.
  */
-inline std::string read_dump_file(const std::string& path, KeyDumpHeader& hdr, std::vector<uint64_t>& keys) {
+inline std::string read_dump_file(const std::string& path, KeyDumpHeader& hdr, std::vector<uint32_t>& keys) {
     std::ifstream in(path, std::ios::binary);
     if (!in)
         return "cannot open '" + path + "'";
@@ -126,7 +126,7 @@ inline std::string read_dump_file(const std::string& path, KeyDumpHeader& hdr, s
 
     keys.resize(hdr.n_keys);
     in.read(
-        reinterpret_cast<char*>(keys.data()), static_cast<std::streamsize>(hdr.n_keys * sizeof(uint64_t))
+        reinterpret_cast<char*>(keys.data()), static_cast<std::streamsize>(hdr.n_keys * sizeof(uint32_t))
     );
     if (!in)
         return "failed to read " + std::to_string(hdr.n_keys) + " keys";
@@ -175,7 +175,7 @@ struct KeyDumper {
     static constexpr bool is_enabled = false;
 
     explicit KeyDumper(const char*) {}
-    void dump(const std::vector<uint64_t>&, uint32_t, uint64_t) {}
+    void dump(const std::vector<uint32_t>&, uint32_t, uint64_t) {}
 };
 
 /**
@@ -197,7 +197,7 @@ struct KeyDumper<true> {
         dump_log_.open(resolve_dump_jsonl(dir_), std::ios::app);
     }
 
-    void dump(const std::vector<uint64_t>& keys, uint32_t trie_id, uint64_t node_pos) {
+    void dump(const std::vector<uint32_t>& keys, uint32_t trie_id, uint64_t node_pos) {
         if (keys.empty())
             return;
 
@@ -207,8 +207,8 @@ struct KeyDumper<true> {
             "_n" + std::to_string(hdr.n_keys) + ".bin";
         write_dump_file(dir_ + "/" + fname, hdr, keys);
 
-        uint64_t key_min = keys[0], key_max = keys[0];
-        for (uint64_t k : keys) {
+        uint32_t key_min = keys[0], key_max = keys[0];
+        for (uint32_t k : keys) {
             if (k < key_min)
                 key_min = k;
             if (k > key_max)

--- a/include/hashing/key_policies.hpp
+++ b/include/hashing/key_policies.hpp
@@ -22,7 +22,7 @@ struct KeyInitContext {
     const std::array<uint64_t, 3>& multipliers;
     const std::array<uint64_t, 3>& biases;
     const std::array<uint64_t, 3>& segment_starts;
-    uint64_t max_mixed_key;  // upper bound for the post-mixer key domain used by the policy
+    uint32_t max_mixed_key;  // upper bound for the post-mixer key domain used by the policy
 };
 
 struct NoKey {
@@ -31,7 +31,7 @@ struct NoKey {
 
     void init(const KeyInitContext&) {}
 
-    void store(size_t, uint64_t, const Triple&, int) {}
+    void store(size_t, uint32_t, const Triple&, int) {}
 
     size_t size_in_bytes() const { return 0; }
 
@@ -47,15 +47,15 @@ struct FullKey {
     static constexpr bool supports_contains = true;
     static constexpr bool needs_input_stats = false;
 
-    std::vector<uint64_t> keys_;
+    std::vector<uint32_t> keys_;
 
     void init(const KeyInitContext& ctx) { keys_.assign(ctx.n, 0); }
 
-    void store(size_t idx, uint64_t key, const Triple&, int) { keys_[idx] = key; }
+    void store(size_t idx, uint32_t key, const Triple&, int) { keys_[idx] = key; }
 
-    bool verify(size_t idx, uint64_t key, int) const { return keys_[idx] == key; }
+    bool verify(size_t idx, uint32_t key, int) const { return keys_[idx] == key; }
 
-    size_t size_in_bytes() const { return sizeof(uint64_t) * keys_.size(); }
+    size_t size_in_bytes() const { return sizeof(uint32_t) * keys_.size(); }
 
     // Context binding: FullKey does not depend on hash parameters.
     void bind_context(const KeyInitContext&) {}
@@ -70,9 +70,9 @@ struct FullKey {
         if (sz > 0) {
             out.write(
                 reinterpret_cast<const char*>(keys_.data()),
-                static_cast<std::streamsize>(sz * sizeof(uint64_t))
+                static_cast<std::streamsize>(sz * sizeof(uint32_t))
             );
-            written += sz * sizeof(uint64_t);
+            written += sz * sizeof(uint32_t);
         }
 
         sdsl::structure_tree::add_size(child, written);
@@ -85,7 +85,7 @@ struct FullKey {
         keys_.resize(static_cast<size_t>(sz));
         if (sz > 0) {
             in.read(
-                reinterpret_cast<char*>(keys_.data()), static_cast<std::streamsize>(sz * sizeof(uint64_t))
+                reinterpret_cast<char*>(keys_.data()), static_cast<std::streamsize>(sz * sizeof(uint32_t))
             );
         }
     }
@@ -122,13 +122,13 @@ struct QuotientKey {
         if (ctx.max_mixed_key > 0) {
             q_max = ctx.max_mixed_key / p_min;
         } else {
-            q_max = std::numeric_limits<uint64_t>::max() / p_min;
+            q_max = std::numeric_limits<uint32_t>::max() / p_min;
         }
         uint8_t quotient_width = (q_max == 0) ? 1 : static_cast<uint8_t>(sdsl::bits::hi(q_max) + 1);
         quotients_ = sdsl::int_vector<>(ctx.n, 0, quotient_width);
     }
 
-    void store(size_t idx, uint64_t mixed_key, const Triple&, int which_h) {
+    void store(size_t idx, uint32_t mixed_key, const Triple&, int which_h) {
         assert(idx < quotients_.size());
         assert(which_h >= 0 && which_h <= 2);
 
@@ -139,7 +139,7 @@ struct QuotientKey {
         quotients_[idx] = q;
     }
 
-    bool verify(size_t idx, uint64_t mixed_key, int which_h) const {
+    bool verify(size_t idx, uint32_t mixed_key, int which_h) const {
         if (idx >= quotients_.size())
             return false;
         if (which_h < 0 || which_h > 2)

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -114,7 +114,7 @@ class MPHF {
      * @brief Build MPHF for given keys (no tracing).
      * Delegates to the traced overload with a no-op tracer (zero overhead).
      */
-    bool build(const std::vector<uint64_t>& keys) {
+    bool build(const std::vector<uint32_t>& keys) {
         hashing::MphfBuildTracer<false> noop("");
         return build(keys, noop);
     }
@@ -125,7 +125,7 @@ class MPHF {
      * Timing is only measured when Tracer::is_enabled is true (zero-cost otherwise).
      */
     template <typename Tracer>
-    bool build(const std::vector<uint64_t>& keys, Tracer& tracer) {
+    bool build(const std::vector<uint32_t>& keys, Tracer& tracer) {
         n_ = keys.size();
         if (n_ == 0)
             return false;
@@ -298,7 +298,7 @@ class MPHF {
      *
      * @return true on full peel or accepted fallback; false to request a retry.
      */
-    bool try_build(const std::vector<uint64_t>& keys, int retry_count) {
+    bool try_build(const std::vector<uint32_t>& keys, int retry_count) {
         if (!initialize_hash_functions(keys, retry_count)) {
             return false;
         }
@@ -331,17 +331,17 @@ class MPHF {
             residual_keys_.reserve(residual_count);
             for (uint32_t i = 0; i < static_cast<uint32_t>(triples.size()); ++i) {
                 if (!edge_removed[i]) {
-                    residual_keys_.push_back(static_cast<uint32_t>(triples[i].mixed_key));
+                    residual_keys_.push_back(triples[i].mixed_key);
                 }
             }
             std::sort(residual_keys_.begin(), residual_keys_.end());
         }
 
         // Quotient width uses the max mixed key over the full input.
-        uint64_t max_mixed_key = 0;
+        uint32_t max_mixed_key = 0;
         if constexpr (KeyPolicy::needs_input_stats) {
             for (auto k : keys) {
-                uint64_t mixed_key = static_cast<uint64_t>(premix32(static_cast<uint32_t>(k)));
+                uint32_t mixed_key = premix32(k);
                 if (mixed_key > max_mixed_key)
                     max_mixed_key = mixed_key;
             }
@@ -375,14 +375,13 @@ class MPHF {
      * @param key Key to query
      * @return Hash value in range [0, n)
      */
-    uint32_t query(uint64_t key) const {
+    uint32_t query(uint32_t key) const {
         auto triple = compute_triple(key);
 
         // Residual keys bypass the BDZ path.
         if (!residual_keys_.empty()) {
-            uint32_t mixed_key_u32 = static_cast<uint32_t>(triple.mixed_key);
-            auto it = std::lower_bound(residual_keys_.begin(), residual_keys_.end(), mixed_key_u32);
-            if (it != residual_keys_.end() && *it == mixed_key_u32) {
+            auto it = std::lower_bound(residual_keys_.begin(), residual_keys_.end(), triple.mixed_key);
+            if (it != residual_keys_.end() && *it == triple.mixed_key) {
                 return n_peeled_ + static_cast<uint32_t>(it - residual_keys_.begin());
             }
         }
@@ -403,7 +402,7 @@ class MPHF {
      * For peeled keys, slot is the BDZ rank; for fallback keys, slot is n_peeled_ + offset.
      */
     template <typename K = KeyPolicy>
-    std::enable_if_t<K::supports_contains, std::pair<bool, uint32_t>> locate(uint64_t key) const {
+    std::enable_if_t<K::supports_contains, std::pair<bool, uint32_t>> locate(uint32_t key) const {
         if (n_ == 0)
             return {false, 0};
 
@@ -411,9 +410,8 @@ class MPHF {
 
         // Fallback path: check residual keys via binary search.
         if (!residual_keys_.empty()) {
-            uint32_t mixed_key_u32 = static_cast<uint32_t>(triple.mixed_key);
-            auto it = std::lower_bound(residual_keys_.begin(), residual_keys_.end(), mixed_key_u32);
-            if (it != residual_keys_.end() && *it == mixed_key_u32)
+            auto it = std::lower_bound(residual_keys_.begin(), residual_keys_.end(), triple.mixed_key);
+            if (it != residual_keys_.end() && *it == triple.mixed_key)
                 return {true, n_peeled_ + static_cast<uint32_t>(it - residual_keys_.begin())};
         }
 
@@ -434,7 +432,7 @@ class MPHF {
      * @brief Check if a key is in the set (only enabled if KeyPolicy supports it).
      */
     template <typename K = KeyPolicy>
-    std::enable_if_t<K::supports_contains, bool> contains(uint64_t key) const {
+    std::enable_if_t<K::supports_contains, bool> contains(uint32_t key) const {
         return locate(key).first;
     }
 
@@ -455,7 +453,7 @@ class MPHF {
      * primes near m/3, later retries bump one prime at a time and resample a_k, b_k
      * to vary the hypergraph while keeping m essentially constant.
      */
-    bool initialize_hash_functions(const std::vector<uint64_t>& keys, int retry_count) {
+    bool initialize_hash_functions(const std::vector<uint32_t>& keys, int retry_count) {
         const uint64_t target_segment = compute_target_segment();
 
         if (retry_count == 0) {
@@ -512,7 +510,7 @@ class MPHF {
     /**
      * @brief Generate triples for all keys using the three hash functions
      */
-    std::vector<Triple> generate_triples(const std::vector<uint64_t>& keys) {
+    std::vector<Triple> generate_triples(const std::vector<uint32_t>& keys) {
         std::vector<Triple> triples;
         triples.reserve(keys.size());
         for (auto x : keys) {
@@ -625,14 +623,14 @@ class MPHF {
                 }
             }
 
-            uint64_t mixed_key_min = triples[0].mixed_key, mixed_key_max = triples[0].mixed_key;
+            uint32_t mixed_key_min = triples[0].mixed_key, mixed_key_max = triples[0].mixed_key;
             for (const auto& t : triples) {
                 if (t.mixed_key < mixed_key_min)
                     mixed_key_min = t.mixed_key;
                 if (t.mixed_key > mixed_key_max)
                     mixed_key_max = t.mixed_key;
             }
-            uint64_t mixed_key_range = mixed_key_max - mixed_key_min + 1;
+            uint64_t mixed_key_range = static_cast<uint64_t>(mixed_key_max) - mixed_key_min + 1;
             double density = static_cast<double>(triples.size()) / static_cast<double>(mixed_key_range);
 
             LOG_WARN(
@@ -719,15 +717,9 @@ class MPHF {
      * Applies premix32 before hashing to destroy arithmetic structure.
      * triple.mixed_key stores the mixed value premix32(key); the key policy
      * operates on that mixed value (not the original key) so that quotienting remains valid.
-     * Precondition: key must fit in uint32_t, since premix32 is defined over
-     * the uint32 domain and larger inputs would truncate silently.
      */
-    Triple compute_triple(uint64_t key) const {
-        assert(
-            key <= static_cast<uint64_t>(UINT32_MAX) &&
-            "premix32 requires keys to fit in uint32_t; larger inputs would truncate"
-        );
-        uint64_t mixed_key = static_cast<uint64_t>(premix32(static_cast<uint32_t>(key)));
+    Triple compute_triple(uint32_t key) const {
+        uint32_t mixed_key = premix32(key);
         return Triple(
             mixed_key, hash_function(mixed_key, 0), hash_function(mixed_key, 1), hash_function(mixed_key, 2)
         );

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <queue>
 #include <random>
 #include <sdsl/bit_vectors.hpp>
@@ -470,6 +471,11 @@ class MPHF {
             primes_[static_cast<size_t>(idx)] = next_prime(primes_[static_cast<size_t>(idx)] + 1);
         }
 
+        assert(
+            std::max({primes_[0], primes_[1], primes_[2]}) <= std::numeric_limits<uint32_t>::max() &&
+            "p_k must fit in uint32_t so that a_k*x stays within uint64_t in hash_function"
+        );
+
         // Compute segment starts and total m
         segment_starts_[0] = 0;
         segment_starts_[1] = primes_[0];
@@ -701,11 +707,14 @@ class MPHF {
      * @brief Compute hash function h_k(x) for k ∈ {0,1,2}
      * h_k(x) = d_k + ((a_k · x + b_k) mod r_k)
      * with r_k = primes_[k], a_k = multipliers_[k], b_k = biases_[k], d_k = segment_starts_[k].
+     *
+     * Since a_k < p_k < 2^32, x < 2^32, the product a_k·x fits in uint64_t with no overflow.
+     * Reminder: p_k ≈ m/3, m = 1.25·n => p_k ≈ 0.4167·n, and n < 2^32 => p_k < 2^31.
      */
-    uint32_t hash_function(uint64_t x, int k) const {
+    uint32_t hash_function(uint32_t x, int k) const {
         const size_t i = static_cast<size_t>(k);
         const uint64_t r = primes_[i];
-        uint64_t mapped = mod_mul(x, multipliers_[i], r);  // in [0, r)
+        uint64_t mapped = (x * multipliers_[i]) % r;  // in [0, r)
         mapped += biases_[i];
         if (mapped >= r)
             mapped -= r;  // single correction instead of modulo

--- a/include/hashing/mphf_types.hpp
+++ b/include/hashing/mphf_types.hpp
@@ -6,12 +6,12 @@ namespace cltj {
 namespace hashing {
 
 struct Triple {
-    uint64_t mixed_key;  // key after applying the pre-hash mixer
+    uint32_t mixed_key;  // key after applying the pre-hash mixer
     uint32_t v0, v1, v2;  // vertices of the hypergraph
 
     Triple() : mixed_key(0), v0(0), v1(0), v2(0) {}
 
-    Triple(uint64_t mixed_key_value, uint32_t vertex0, uint32_t vertex1, uint32_t vertex2)
+    Triple(uint32_t mixed_key_value, uint32_t vertex0, uint32_t vertex1, uint32_t vertex2)
         : mixed_key(mixed_key_value), v0(vertex0), v1(vertex1), v2(vertex2) {}
 
     uint32_t v(int idx) const {

--- a/include/metatrie/compact_metatrie_hash.hpp
+++ b/include/metatrie/compact_metatrie_hash.hpp
@@ -140,7 +140,7 @@ class compact_metatrie_hash {
      */
     bool hash_contains(size_type node_pos, value_type key) const {
         size_type mphf_idx = m_hash_rank(node_pos);
-        return m_mphfs[mphf_idx].contains(static_cast<uint64_t>(key));
+        return m_mphfs[mphf_idx].contains(key);
     }
 
     /** 
@@ -151,7 +151,7 @@ class compact_metatrie_hash {
      */
     std::pair<bool, uint32_t> hash_locate(size_type node_pos, value_type key) const {
         size_type mphf_idx = m_hash_rank(node_pos);
-        return m_mphfs[mphf_idx].locate(static_cast<uint64_t>(key));
+        return m_mphfs[mphf_idx].locate(key);
     }
 
     /**
@@ -168,7 +168,7 @@ class compact_metatrie_hash {
         size_type mphf_idx = m_hash_rank(0);
         std::vector<size_type> perm(d);
         for (size_type i = 0; i < d; i++) {
-            uint64_t key = static_cast<uint64_t>(m_seq[i]);
+            value_type key = m_seq[i];
             auto [found, slot] = m_mphfs[mphf_idx].locate(key);
             perm[slot] = i;
         }
@@ -251,10 +251,10 @@ class compact_metatrie_hash {
             for (auto node : current_level) {
                 size_type n_children = children(node);
                 if (n_children >= threshold) {
-                    std::vector<uint64_t> keys;
+                    std::vector<uint32_t> keys;
                     keys.reserve(n_children);
                     for (size_type k = 0; k < n_children; k++)
-                        keys.push_back(static_cast<uint64_t>(m_seq[node + k]));
+                        keys.push_back(m_seq[node + k]);
 
                     tracer.on_node_start(trie_id, node, n_children, threshold);
                     mphf_type mphf;
@@ -350,7 +350,7 @@ class compact_metatrie_hash {
                     // Hashed node: build permutation from MPHF
                     size_type mphf_idx = m_hash_rank(old_pos);
                     for (size_type i = 0; i < n_children; i++) {
-                        uint64_t key = static_cast<uint64_t>(m_seq[old_pos + i]);
+                        value_type key = m_seq[old_pos + i];
                         auto [found, slot] = m_mphfs[mphf_idx].locate(key);
                         perm[slot] = i;
                     }

--- a/src/bench/bench_mphf_hashing.cpp
+++ b/src/bench/bench_mphf_hashing.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <string>
 #include <unordered_set>
@@ -31,17 +32,19 @@ namespace ph = pthash;
 
 namespace {
 
-// Generate a vector of unique random keys in a reasonable range.
-static std::vector<uint64_t> generate_unique_keys(size_t n, uint64_t seed) {
+// Generate a vector of unique random keys in the uint32 domain.
+static std::vector<uint32_t> generate_unique_keys(size_t n, uint64_t seed) {
     std::mt19937_64 rng(seed);
-    std::unordered_set<uint64_t> unique_keys;
+    std::unordered_set<uint32_t> unique_keys;
     unique_keys.reserve(n * 2);
-    // Generate keys in a range up to 100*n to reduce collisions during generation.
-    std::uniform_int_distribution<uint64_t> dist(1, n * 100);
+    // Generate keys in a range up to 100*n to reduce collisions during generation,
+    // capped to the MPHF's uint32 domain for large n.
+    uint64_t max_key = std::min<uint64_t>(n * 100, std::numeric_limits<uint32_t>::max());
+    std::uniform_int_distribution<uint32_t> dist(1, static_cast<uint32_t>(max_key));
     while (unique_keys.size() < n) {
         unique_keys.insert(dist(rng));
     }
-    return std::vector<uint64_t>(unique_keys.begin(), unique_keys.end());
+    return std::vector<uint32_t>(unique_keys.begin(), unique_keys.end());
 }
 
 struct BenchConfig {
@@ -107,7 +110,7 @@ BenchResult run_bench_case(const std::string& strategy_name, size_t n, uint64_t 
     volatile uint64_t sink = 0;  // prevent the compiler from optimizing queries away
     auto start_query = std::chrono::high_resolution_clock::now();
     for (size_t rep = 0; rep < query_reps; ++rep) {
-        for (uint64_t k : keys) {
+        for (uint32_t k : keys) {
             uint32_t h = mphf.query(k);
             sink ^= h;
         }

--- a/src/test/hashing/repro_mphf_build.cpp
+++ b/src/test/hashing/repro_mphf_build.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
 
     // --- Read and validate dump ---
     cltj::hashing::KeyDumpHeader hdr{};
-    std::vector<uint64_t> keys;
+    std::vector<uint32_t> keys;
     std::string err = cltj::hashing::read_dump_file(dump_file, hdr, keys);
     if (!err.empty()) {
         std::cerr << "error: " << err << "\n";
@@ -83,8 +83,8 @@ int main(int argc, char** argv) {
     }
 
     // Key-range diagnostics
-    uint64_t key_min = keys[0], key_max = keys[0];
-    for (uint64_t k : keys) {
+    uint32_t key_min = keys[0], key_max = keys[0];
+    for (uint32_t k : keys) {
         if (k < key_min)
             key_min = k;
         if (k > key_max)

--- a/src/test/hashing/test_mphf.cpp
+++ b/src/test/hashing/test_mphf.cpp
@@ -19,15 +19,15 @@ using cltj::hashing::PackedTritStorage;
 using cltj::hashing::policies::FullKey;
 
 // Helper to generate a vector of unique random keys in a reasonable range.
-static std::vector<uint64_t> generate_reasonable_keys(size_t n, uint64_t seed) {
+static std::vector<uint32_t> generate_reasonable_keys(size_t n, uint64_t seed) {
     std::mt19937_64 rng(seed);
-    std::unordered_set<uint64_t> unique_keys;
+    std::unordered_set<uint32_t> unique_keys;
     // Generate keys in a range up to 100*n to reduce collisions during generation.
-    std::uniform_int_distribution<uint64_t> dist(1, n * 100);
+    std::uniform_int_distribution<uint32_t> dist(1, static_cast<uint32_t>(n * 100));
     while (unique_keys.size() < n) {
         unique_keys.insert(dist(rng));
     }
-    return std::vector<uint64_t>(unique_keys.begin(), unique_keys.end());
+    return std::vector<uint32_t>(unique_keys.begin(), unique_keys.end());
 }
 
 // A struct to hold all the results from a single test run.
@@ -106,13 +106,13 @@ TestResult run_test_case(size_t n) {
     // 3. Check for False Positives
     if (result.is_permutation) {
         size_t negative_sample_size = std::min((size_t)100000, n);  // Limit sample size
-        std::unordered_set<uint64_t> key_set(keys.begin(), keys.end());
+        std::unordered_set<uint32_t> key_set(keys.begin(), keys.end());
         std::mt19937_64 rng(12345 + n);  // Different seed from keygen
         size_t false_positives = 0;
         for (size_t i = 0; i < negative_sample_size; ++i) {
-            uint64_t non_key;
+            uint32_t non_key;
             do {
-                non_key = static_cast<uint32_t>(rng());  // premix32 domain: keys must fit in uint32_t
+                non_key = static_cast<uint32_t>(rng());
             } while (key_set.count(non_key));  // Ensure it's not actually a key
 
             if (mphf.contains(non_key)) {

--- a/src/test/hashing/test_mphf_adversarial.cpp
+++ b/src/test/hashing/test_mphf_adversarial.cpp
@@ -120,15 +120,15 @@ class TestReport {
  * @param max_value Maximum value for keys (default: UINT32_MAX, because premix32 maps keys to [0, 2^32))
  * @param seed Random seed for reproducibility
  */
-std::vector<uint64_t> generate_random_keys(size_t n, uint64_t seed = 42, uint64_t max_value = UINT32_MAX) {
-    std::vector<uint64_t> keys;
+std::vector<uint32_t> generate_random_keys(size_t n, uint64_t seed = 42, uint32_t max_value = UINT32_MAX) {
+    std::vector<uint32_t> keys;
     keys.reserve(n);
 
     std::mt19937_64 rng(seed);
-    std::uniform_int_distribution<uint64_t> dist(0, max_value);
+    std::uniform_int_distribution<uint32_t> dist(0, max_value);
 
     // Use a set to ensure uniqueness
-    std::set<uint64_t> unique_keys;
+    std::set<uint32_t> unique_keys;
     while (unique_keys.size() < n) {
         unique_keys.insert(dist(rng));
     }
@@ -180,7 +180,7 @@ TestResult test_dopplerganger_attack() {
 
         // Setup: Build MPHF with random keys
         const size_t N = 10000;
-        std::vector<uint64_t> keys = generate_random_keys(N);
+        std::vector<uint32_t> keys = generate_random_keys(N);
 
         MPHF<GlGhStorage, policies::QuotientKey> mphf;
         if (!mphf.build(keys)) {
@@ -191,19 +191,19 @@ TestResult test_dopplerganger_attack() {
         auto primes = mphf.get_primes();
 
         // Attack: For each key, generate impostors with same remainder
-        for (uint64_t x : keys) {
+        for (uint32_t x : keys) {
             for (uint64_t p : primes) {
                 // Impostor up: x' = x + p (same r, q' = q+1)
-                uint64_t impostor_up = x + p;
+                uint64_t impostor_up = static_cast<uint64_t>(x) + p;
                 if (impostor_up <= UINT32_MAX) {
                     result.checks_run++;
-                    if (mphf.contains(impostor_up))
+                    if (mphf.contains(static_cast<uint32_t>(impostor_up)))
                         result.false_positives++;
                 }
 
                 // Impostor down: x' = x - p (same r, q' = q-1)
                 if (x >= p) {
-                    uint64_t impostor_down = x - p;
+                    uint32_t impostor_down = x - static_cast<uint32_t>(p);
                     result.checks_run++;
                     if (mphf.contains(impostor_down))
                         result.false_positives++;
@@ -212,7 +212,7 @@ TestResult test_dopplerganger_attack() {
         }
 
         // Verify: All stored keys should still be found
-        for (uint64_t x : keys) {
+        for (uint32_t x : keys) {
             result.checks_run++;
             if (!mphf.contains(x)) {
                 result.false_negatives++;
@@ -257,7 +257,7 @@ TestResult test_zero_quotient_edge_case() {
 
         // We'll use typical primes from a build to determine p_min
         // Build a small MPHF first to get actual primes
-        std::vector<uint64_t> probe_keys = {1, 2, 3};
+        std::vector<uint32_t> probe_keys = {1, 2, 3};
         MPHF<GlGhStorage, policies::QuotientKey> probe_mphf;
         if (!probe_mphf.build(probe_keys)) {
             result.error_message = "Failed to build probe MPHF";
@@ -267,9 +267,9 @@ TestResult test_zero_quotient_edge_case() {
         uint64_t p_min = std::min({primes[0], primes[1], primes[2]});
 
         // Generate keys guaranteed to have q=0
-        std::vector<uint64_t> small_keys;
+        std::vector<uint32_t> small_keys;
         const size_t N = std::min(static_cast<uint64_t>(10000), p_min);
-        for (uint64_t i = 0; i < N; ++i) {
+        for (uint32_t i = 0; i < N; ++i) {
             small_keys.push_back(i);
         }
 
@@ -280,7 +280,7 @@ TestResult test_zero_quotient_edge_case() {
         }
 
         // Verify all keys with q=0 are present
-        for (uint64_t k : small_keys) {
+        for (uint32_t k : small_keys) {
             result.checks_run++;
             if (!mphf.contains(k)) {
                 result.false_negatives++;
@@ -289,7 +289,7 @@ TestResult test_zero_quotient_edge_case() {
 
         // Verify non-keys with q=0 are rejected
         uint64_t test_limit = std::min(static_cast<uint64_t>(N) + 1000, p_min);
-        for (uint64_t i = N; i < test_limit; ++i) {
+        for (uint32_t i = static_cast<uint32_t>(N); i < test_limit; ++i) {
             result.checks_run++;
             if (mphf.contains(i)) {
                 result.false_positives++;
@@ -336,11 +336,11 @@ TestResult test_dense_cluster_attack() {
         std::cout << "\nRunning: " << result.test_name << "...\n";
 
         const size_t N = 20000;  // Reduced to 20K for BDZ to be able to construct
-        std::vector<uint64_t> dense_keys;
+        std::vector<uint32_t> dense_keys;
         dense_keys.reserve(N);
 
         // Insert consecutive keys
-        for (uint64_t i = 0; i < N; ++i) {
+        for (uint32_t i = 0; i < N; ++i) {
             dense_keys.push_back(i);
         }
 
@@ -351,7 +351,7 @@ TestResult test_dense_cluster_attack() {
         }
 
         // Verify all present
-        for (uint64_t k : dense_keys) {
+        for (uint32_t k : dense_keys) {
             result.checks_run++;
             if (!mphf.contains(k)) {
                 result.false_negatives++;
@@ -371,7 +371,7 @@ TestResult test_dense_cluster_attack() {
 
         // Verify random gaps beyond cluster
         std::mt19937_64 rng(42);
-        std::uniform_int_distribution<uint64_t> dist(N + 1, N + 100000);
+        std::uniform_int_distribution<uint32_t> dist(N + 1, N + 100000);
         for (int i = 0; i < 1000; ++i) {
             result.checks_run++;
             if (mphf.contains(dist(rng))) {
@@ -410,10 +410,10 @@ TestResult test_uint32_boundary() {
     try {
         std::cout << "\nRunning: " << result.test_name << "...\n";
 
-        std::vector<uint64_t> edge_keys = {
-            static_cast<uint64_t>(UINT32_MAX),
-            static_cast<uint64_t>(UINT32_MAX) - 1,
-            static_cast<uint64_t>(UINT32_MAX) - 12345,
+        std::vector<uint32_t> edge_keys = {
+            UINT32_MAX,
+            UINT32_MAX - 1,
+            UINT32_MAX - 12345,
             (1ULL << 31),  // 2^31 (MSB of uint32)
             (1ULL << 31) + 1,
             (1ULL << 31) - 1,
@@ -428,7 +428,7 @@ TestResult test_uint32_boundary() {
         }
 
         // Verify all present
-        for (uint64_t k : edge_keys) {
+        for (uint32_t k : edge_keys) {
             result.checks_run++;
             if (!mphf.contains(k)) {
                 result.false_negatives++;
@@ -436,9 +436,9 @@ TestResult test_uint32_boundary() {
         }
 
         // Verify neighbors not inserted
-        std::vector<uint64_t> non_keys = {
-            static_cast<uint64_t>(UINT32_MAX) - 2,
-            static_cast<uint64_t>(UINT32_MAX) - 3,
+        std::vector<uint32_t> non_keys = {
+            UINT32_MAX - 2,
+            UINT32_MAX - 3,
             (1ULL << 31) + 2,
             (1ULL << 31) - 2,
             (1ULL << 16) + 1,
@@ -446,7 +446,7 @@ TestResult test_uint32_boundary() {
             1
         };
 
-        for (uint64_t nk : non_keys) {
+        for (uint32_t nk : non_keys) {
             if (std::find(edge_keys.begin(), edge_keys.end(), nk) == edge_keys.end()) {
                 result.checks_run++;
                 if (mphf.contains(nk)) {
@@ -496,7 +496,7 @@ TestResult test_remainder_zero_edge_case() {
         std::cout << "\nRunning: " << result.test_name << "...\n";
 
         // Build a small MPHF to get primes
-        std::vector<uint64_t> probe_keys = {1, 2, 3};
+        std::vector<uint32_t> probe_keys = {1, 2, 3};
         MPHF<GlGhStorage, policies::QuotientKey> probe_mphf;
         if (!probe_mphf.build(probe_keys)) {
             result.error_message = "Failed to build probe MPHF";
@@ -506,10 +506,10 @@ TestResult test_remainder_zero_edge_case() {
         uint64_t p_min = std::min({primes[0], primes[1], primes[2]});
 
         // Generate keys guaranteed to have r=0 for at least one hash function
-        std::vector<uint64_t> remainder_zero_keys;
+        std::vector<uint32_t> remainder_zero_keys;
         const size_t N = 1000;
         for (uint64_t k = 1; k <= N; ++k) {
-            remainder_zero_keys.push_back(k * p_min);  // r=0, q=k
+            remainder_zero_keys.push_back(static_cast<uint32_t>(k * p_min));  // r=0, q=k
         }
 
         MPHF<GlGhStorage, policies::QuotientKey> mphf;
@@ -519,7 +519,7 @@ TestResult test_remainder_zero_edge_case() {
         }
 
         // Verify all present
-        for (uint64_t k : remainder_zero_keys) {
+        for (uint32_t k : remainder_zero_keys) {
             result.checks_run++;
             if (!mphf.contains(k)) {
                 result.false_negatives++;
@@ -529,7 +529,7 @@ TestResult test_remainder_zero_edge_case() {
         // Verify non-stored multiples are rejected
         for (uint64_t k = N + 1; k <= N + 100; ++k) {
             result.checks_run++;
-            if (mphf.contains(k * p_min)) {
+            if (mphf.contains(static_cast<uint32_t>(k * p_min))) {
                 result.false_positives++;
             }
         }
@@ -589,10 +589,10 @@ TestResult test_quotient_vs_fullkey() {
         }
 
         // Create unordered_set for O(1) lookup instead of O(n) linear search
-        std::unordered_set<uint64_t> key_set(test_keys.begin(), test_keys.end());
+        std::unordered_set<uint32_t> key_set(test_keys.begin(), test_keys.end());
 
         // Verify all positives
-        for (uint64_t k : test_keys) {
+        for (uint32_t k : test_keys) {
             result.checks_run++;
             bool q = mphf_quotient.contains(k);
             bool f = mphf_full.contains(k);
@@ -610,11 +610,11 @@ TestResult test_quotient_vs_fullkey() {
 
         // Verify random non-keys
         std::mt19937_64 rng(999);
-        std::uniform_int_distribution<uint64_t> dist(0, UINT32_MAX);
+        std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX);
 
         size_t non_key_tests = 0;
         while (non_key_tests < 100000) {
-            uint64_t non_key = dist(rng);
+            uint32_t non_key = dist(rng);
 
             // Ensure it's actually not a key (O(1) with unordered_set)
             if (key_set.find(non_key) != key_set.end()) {
@@ -695,7 +695,7 @@ TestResult test_determinism() {
         }
 
         // Verify all keys match
-        for (uint64_t k : keys) {
+        for (uint32_t k : keys) {
             result.checks_run++;
             bool r1 = mphf1.contains(k);
             bool r2 = mphf2.contains(k);
@@ -710,10 +710,10 @@ TestResult test_determinism() {
 
         // Verify non-keys match
         std::mt19937_64 rng(555);
-        std::uniform_int_distribution<uint64_t> dist(0, UINT32_MAX);
+        std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX);
 
         for (int i = 0; i < 10000; ++i) {
-            uint64_t non_key = dist(rng);
+            uint32_t non_key = dist(rng);
             if (std::find(keys.begin(), keys.end(), non_key) != keys.end()) {
                 continue;
             }
@@ -774,7 +774,7 @@ TestResult test_cross_segment_collision() {
 
         // Collect all indices
         std::unordered_set<uint32_t> indices;
-        for (uint64_t k : keys) {
+        for (uint32_t k : keys) {
             result.checks_run++;
 
             // Note: contains() doesn't return the index directly,

--- a/src/test/hashing/test_mphf_move.cpp
+++ b/src/test/hashing/test_mphf_move.cpp
@@ -10,13 +10,13 @@
 
 using MPHF_type = cltj::hashing::MPHF<cltj::hashing::GlGhStorage, cltj::hashing::policies::QuotientKey>;
 
-static std::vector<uint64_t> make_keys(size_t n, uint64_t seed) {
+static std::vector<uint32_t> make_keys(size_t n, uint64_t seed) {
     std::mt19937_64 rng(seed);
-    std::unordered_set<uint64_t> seen;
-    std::uniform_int_distribution<uint64_t> dist(1, n * 100);
+    std::unordered_set<uint32_t> seen;
+    std::uniform_int_distribution<uint32_t> dist(1, static_cast<uint32_t>(n * 100));
     while (seen.size() < n)
         seen.insert(dist(rng));
-    return std::vector<uint64_t>(seen.begin(), seen.end());
+    return std::vector<uint32_t>(seen.begin(), seen.end());
 }
 
 int main() {
@@ -26,13 +26,13 @@ int main() {
     // Build N/1000 small MPHFs and push them into a vector.
     // The vector will reallocate and move elements internally.
     std::vector<MPHF_type> mphfs;
-    std::vector<std::vector<uint64_t>> all_keys;
+    std::vector<std::vector<uint32_t>> all_keys;
 
     const size_t num_mphfs = 5;
     const size_t keys_per_mphf = N / num_mphfs;
 
     for (size_t i = 0; i < num_mphfs; ++i) {
-        std::vector<uint64_t> chunk(keys.begin() + i * keys_per_mphf, keys.begin() + (i + 1) * keys_per_mphf);
+        std::vector<uint32_t> chunk(keys.begin() + i * keys_per_mphf, keys.begin() + (i + 1) * keys_per_mphf);
         all_keys.push_back(chunk);
 
         MPHF_type mphf;
@@ -47,7 +47,7 @@ int main() {
     // Verify each MPHF still works correctly after potential reallocation.
     int failures = 0;
     for (size_t i = 0; i < num_mphfs; ++i) {
-        for (uint64_t key : all_keys[i]) {
+        for (uint32_t key : all_keys[i]) {
             if (!mphfs[i].contains(key)) {
                 std::cerr << "FAIL: contains() returned false for key " << key << " in mphf " << i
                           << " (after move into vector)" << std::endl;

--- a/src/test/hashing/test_mphf_quotient.cpp
+++ b/src/test/hashing/test_mphf_quotient.cpp
@@ -15,8 +15,8 @@ namespace {
 
 struct TestDataset {
     std::string name;
-    std::vector<uint64_t> keys;
-    std::vector<uint64_t> guaranteed_non_keys;
+    std::vector<uint32_t> keys;
+    std::vector<uint32_t> guaranteed_non_keys;
 };
 
 // All key generators use uint32 range because premix32 maps keys to [0, 2^32)
@@ -26,19 +26,19 @@ struct TestDataset {
 TestDataset make_random_dataset(size_t n, uint64_t seed) {
     TestDataset dataset;
     dataset.name = "random-u32";
-    std::unordered_set<uint64_t> key_set;
+    std::unordered_set<uint32_t> key_set;
     key_set.reserve(n);
     std::mt19937 rng(static_cast<uint32_t>(seed));
     while (key_set.size() < n) {
-        key_set.insert(static_cast<uint64_t>(rng()));
+        key_set.insert(rng());
     }
     dataset.keys.assign(key_set.begin(), key_set.end());
 
     std::mt19937 rng_nk(static_cast<uint32_t>(seed ^ 0xABCDEF12ULL));
     for (size_t i = 0; i < n; ++i) {
-        uint64_t candidate;
+        uint32_t candidate;
         do {
-            candidate = static_cast<uint64_t>(rng_nk());
+            candidate = rng_nk();
         } while (key_set.count(candidate));
         dataset.guaranteed_non_keys.push_back(candidate);
     }
@@ -48,16 +48,16 @@ TestDataset make_random_dataset(size_t n, uint64_t seed) {
 TestDataset make_even_odd_dataset(size_t n) {
     TestDataset dataset;
     dataset.name = "even-odd-u32";
-    std::unordered_set<uint64_t> unique;
+    std::unordered_set<uint32_t> unique;
     unique.reserve(n);
     std::mt19937 rng(static_cast<uint32_t>(0xEADDA11CEULL));
     while (unique.size() < n) {
-        uint64_t value = static_cast<uint64_t>(rng()) & ~uint64_t(1);
+        uint32_t value = rng() & ~uint32_t(1);
         unique.insert(value);
     }
     for (auto v : unique) {
         dataset.keys.push_back(v);
-        dataset.guaranteed_non_keys.push_back(v | 1ULL);
+        dataset.guaranteed_non_keys.push_back(v | 1U);
     }
     return dataset;
 }
@@ -65,7 +65,7 @@ TestDataset make_even_odd_dataset(size_t n) {
 // Adversarial: consecutive keys [base, base+n). This is the primary case premix32
 // is designed to solve — dense arithmetic structure that causes peeling failure
 // with linear hash families.
-TestDataset make_consecutive_dataset(size_t n, uint64_t base = 0) {
+TestDataset make_consecutive_dataset(size_t n, uint32_t base = 0) {
     TestDataset dataset;
     dataset.name = "consecutive-" + std::to_string(base) + "+" + std::to_string(n);
     for (size_t i = 0; i < n; ++i) {
@@ -79,7 +79,7 @@ TestDataset make_consecutive_dataset(size_t n, uint64_t base = 0) {
 
 // Adversarial: arithmetic progression {base, base+step, base+2*step, ...}.
 // Exercises the remainder-zero failure mode (all keys share residue structure).
-TestDataset make_arithmetic_progression_dataset(size_t n, uint64_t base, uint64_t step) {
+TestDataset make_arithmetic_progression_dataset(size_t n, uint32_t base, uint32_t step) {
     TestDataset dataset;
     dataset.name = "arith-step" + std::to_string(step);
     for (size_t i = 0; i < n; ++i) {
@@ -92,7 +92,7 @@ TestDataset make_arithmetic_progression_dataset(size_t n, uint64_t base, uint64_
 }
 
 bool run_dataset_test(const TestDataset& dataset,
-                      uint64_t max_key_domain = std::numeric_limits<uint64_t>::max()) {
+                      uint32_t max_key_domain = std::numeric_limits<uint32_t>::max()) {
     MPHF<GlGhStorage, QuotientKey> mphf;
     if (!mphf.build(dataset.keys)) {
         std::cerr << "QuotientKey test failure: build failed for dataset " << dataset.name << "."
@@ -132,7 +132,7 @@ bool run_dataset_test(const TestDataset& dataset,
         if (fake128 > UINT32_MAX) {
             continue;
         }
-        uint64_t fake = static_cast<uint64_t>(fake128);
+        uint32_t fake = static_cast<uint32_t>(fake128);
         if (mphf.contains(fake)) {
             std::cerr << "QuotientKey test failure: key+product accepted (dataset " << dataset.name
                       << ")." << std::endl;
@@ -144,9 +144,7 @@ bool run_dataset_test(const TestDataset& dataset,
     double q_bits_per_key = (breakdown.q_bytes * 8.0) / static_cast<double>(dataset.keys.size());
     uint64_t p_min = std::min({primes[0], primes[1], primes[2]});
     // q_max reflects the highest possible premixed key value divided by the smallest prime.
-    // For 64-bit keys: max_key_domain = UINT64_MAX.
-    // For 32-bit keys (e.g. Wikidata IDs): max_key_domain = UINT32_MAX.
-    uint64_t q_max = max_key_domain / p_min;
+    uint64_t q_max = static_cast<uint64_t>(max_key_domain) / p_min;
     double expected_width = static_cast<double>(sdsl::bits::hi(q_max) + 1);
     if (q_bits_per_key < expected_width || q_bits_per_key > expected_width + 0.5) {
         std::cerr << "QuotientKey test failure: q_bits_per_key=" << q_bits_per_key
@@ -163,7 +161,7 @@ bool run_dataset_test(const TestDataset& dataset,
 int main() {
     // premix32 maps all keys to [0, 2^32) before hashing, so the effective quotient
     // domain is bounded by UINT32_MAX regardless of input key width.
-    constexpr uint64_t premix_domain = std::numeric_limits<uint32_t>::max();
+    constexpr uint32_t premix_domain = std::numeric_limits<uint32_t>::max();
     int n_passed = 0;
 
     // --- Group 1: Random keys (uint32 range) ---

--- a/src/test/hashing/test_mphf_serialization.cpp
+++ b/src/test/hashing/test_mphf_serialization.cpp
@@ -25,38 +25,36 @@ using cltj::hashing::MPHF;
 using cltj::hashing::policies::FullKey;
 
 // Helper to generate unique random keys
-static std::vector<uint64_t> generate_keys(size_t n, uint64_t seed) {
+static std::vector<uint32_t> generate_keys(size_t n, uint64_t seed) {
     std::mt19937_64 rng(seed);
-    std::unordered_set<uint64_t> unique_keys;
-    std::uniform_int_distribution<uint64_t> dist(1, n * 100);
+    std::unordered_set<uint32_t> unique_keys;
+    std::uniform_int_distribution<uint32_t> dist(1, static_cast<uint32_t>(n * 100));
     while (unique_keys.size() < n) {
         unique_keys.insert(dist(rng));
     }
-    return std::vector<uint64_t>(unique_keys.begin(), unique_keys.end());
+    return std::vector<uint32_t>(unique_keys.begin(), unique_keys.end());
 }
 
 template <typename StorageStrategy>
-std::vector<uint64_t> synthesize_fallback_fixture(
-    MPHF<StorageStrategy, FullKey>& mphf, const std::vector<uint64_t>& keys, size_t residual_count
+std::vector<uint32_t> synthesize_fallback_fixture(
+    MPHF<StorageStrategy, FullKey>& mphf, const std::vector<uint32_t>& keys, size_t residual_count
 ) {
     assert(residual_count > 0 && residual_count < keys.size());
 
-    std::vector<std::pair<uint32_t, uint64_t>> indexed_keys;
+    std::vector<std::pair<uint32_t, uint32_t>> indexed_keys;
     indexed_keys.reserve(keys.size());
-    for (uint64_t key : keys) {
+    for (uint32_t key : keys) {
         indexed_keys.emplace_back(mphf.query(key), key);
     }
     std::sort(indexed_keys.begin(), indexed_keys.end());
 
-    std::vector<uint64_t> residual_keys;
+    std::vector<uint32_t> residual_keys;
     residual_keys.reserve(residual_count);
     mphf.residual_keys_.clear();
     for (size_t i = indexed_keys.size() - residual_count; i < indexed_keys.size(); ++i) {
-        uint64_t key = indexed_keys[i].second;
+        uint32_t key = indexed_keys[i].second;
         residual_keys.push_back(key);
-        mphf.residual_keys_.push_back(
-            static_cast<uint32_t>(cltj::hashing::premix32(static_cast<uint32_t>(key)))
-        );
+        mphf.residual_keys_.push_back(cltj::hashing::premix32(key));
     }
     std::sort(mphf.residual_keys_.begin(), mphf.residual_keys_.end());
     mphf.n_peeled_ = static_cast<uint32_t>(keys.size() - residual_count);
@@ -64,7 +62,7 @@ std::vector<uint64_t> synthesize_fallback_fixture(
     // The synthetic fixture should remain a valid MPHF for the original key set.
     std::unordered_set<uint32_t> indices;
     indices.reserve(keys.size());
-    for (uint64_t key : keys) {
+    for (uint32_t key : keys) {
         assert(mphf.contains(key));
         indices.insert(mphf.query(key));
     }
@@ -85,7 +83,7 @@ std::vector<uint64_t> synthesize_fallback_fixture(
  */
 template <typename StorageStrategy>
 void test_roundtrip(
-    const std::vector<uint64_t>& keys,
+    const std::vector<uint32_t>& keys,
     const std::string& strategy_name,
     const std::string& case_label,
     bool synthesize_fallback = false
@@ -100,7 +98,7 @@ void test_roundtrip(
     }
     std::cout << "  [OK] Built original MPHF" << std::endl;
 
-    std::vector<uint64_t> residual_fixture_keys;
+    std::vector<uint32_t> residual_fixture_keys;
     if (synthesize_fallback) {
         residual_fixture_keys = synthesize_fallback_fixture(mphf1, keys, 2);
         std::cout << "  [OK] Synthesized fallback-active fixture with residual=2" << std::endl;
@@ -174,7 +172,7 @@ void test_roundtrip(
     std::cout << "  [OK] All contains() results match" << std::endl;
 
     // 4. Check fallback-system queries explicitly
-    for (uint64_t key : residual_fixture_keys) {
+    for (uint32_t key : residual_fixture_keys) {
         uint32_t h1 = mphf1.query(key);
         uint32_t h2 = mphf2.query(key);
         assert(h1 == h2 && "Fallback query differs after deserialization");
@@ -189,12 +187,12 @@ void test_roundtrip(
     // 5. Check false positives match (sample a few non-keys)
     const size_t n = keys.size();
     std::mt19937_64 rng(12345);
-    std::uniform_int_distribution<uint64_t> non_key_dist(0, UINT32_MAX);
-    std::unordered_set<uint64_t> key_set(keys.begin(), keys.end());
+    std::uniform_int_distribution<uint32_t> non_key_dist(0, UINT32_MAX);
+    std::unordered_set<uint32_t> key_set(keys.begin(), keys.end());
     size_t fp_sample = std::min((size_t)1000, n / 10);
     bool fp_match = true;
     for (size_t i = 0; i < fp_sample; ++i) {
-        uint64_t non_key;
+        uint32_t non_key;
         do {
             non_key = non_key_dist(rng);
         } while (key_set.count(non_key));

--- a/src/test/hashing/test_mphf_size_breakdown.cpp
+++ b/src/test/hashing/test_mphf_size_breakdown.cpp
@@ -24,7 +24,7 @@ namespace {
 template <typename Storage, typename Policy>
 void analyze_strategy(
     const std::string& header,
-    const std::vector<uint64_t>& keys,
+    const std::vector<uint32_t>& keys,
     const std::string& g_label,
     const std::string& used_label,
     const std::string& rank_label
@@ -74,19 +74,19 @@ int main() {
         std::cout << "--- Analysis for n = " << n << " ---" << std::endl;
 
         // Generate test keys (30-bit keys for testing quotient width optimization)
-        constexpr uint64_t KEY_BITS = 30;
-        constexpr uint64_t MAX_KEY_VALUE = (1ULL << KEY_BITS) - 1;
+        constexpr uint32_t KEY_BITS = 30;
+        constexpr uint32_t MAX_KEY_VALUE = (1U << KEY_BITS) - 1;
         std::mt19937_64 rng(42);
 
         // Use set to ensure unique keys
-        std::unordered_set<uint64_t> unique_keys;
+        std::unordered_set<uint32_t> unique_keys;
         unique_keys.reserve(n);
         while (unique_keys.size() < n) {
-            unique_keys.insert(rng() & MAX_KEY_VALUE);
+            unique_keys.insert(static_cast<uint32_t>(rng()) & MAX_KEY_VALUE);
         }
 
         // Convert to vector for MPHF
-        std::vector<uint64_t> keys(unique_keys.begin(), unique_keys.end());
+        std::vector<uint32_t> keys(unique_keys.begin(), unique_keys.end());
 
         analyze_strategy<BaselineStorage, NoKey>(
             "[BaselineStorage]", keys, "G array (2-bit values)", "Used positions bitvector", "Rank support"


### PR DESCRIPTION
## What changed

The MPHF public API now takes `uint32_t` keys instead of `uint64_t` (`build`, `query`, `locate`, `contains`, plus `Triple::mixed_key` and the key policies). `hash_function` reduces with a native 64-bit product instead of the `__uint128_t` `mod_mul`, which drops the `__umodti3` software division from the query path. The redundant casts in `compact_metatrie_hash` and the debug-only truncation assert in `compute_triple` are gone, and the key dump format is bumped to version 2.

## Why

The MPHF was already 32-bit internally: `compute_triple` truncates each key to `uint32_t` before `premix32`, so the `uint64_t` interface was misleading. In release the check against keys `>= 2^32` was a debug-only assert, so those keys got silently truncated and could alias distinct keys into false positives. The `uint32_t` interface matches the real domain and closes that gap.

As a side benefit, the `hash_function` modulo no longer needs `__uint128_t`. With the key narrowed to `uint32_t` (`key < 2^32`) and the multiplier bounded by the prime (`multiplier < 2^31`), the product `key * multiplier < 2^63` fits in a `uint64_t`. The compiler emits a native `divq` for the modulo instead of calling the 128-bit software division `__umodti3`.

## Implementation notes

- `primes_`, `multipliers_`, and `biases_` stay `uint64_t`, so `x * a_k` promotes to a 64-bit product on its own (a `uint32_t * uint32_t` product would wrap) and the build-time prime code keeps working. A build-time assert checks `p_k <= 2^32`, which always holds since `p_k ≈ 0.417·n` and `n` is a `uint32_t`.
- `FullKey` (test/benchmark only) drops its payload to `uint32_t`. The production policies (`NoKey`, `QuotientKey`) keep the exact same on-disk format.
- The key dump format is not backward compatible; the existing version check rejects old dumps.

## Out of scope

fastmod/fastdiv in the quotienting path is left for a follow-up so it can be measured before integrating. `mphf_utils` (`mod_mul`, `is_prime`, ...) stays 64-bit for build-time prime generation.

## Validation

`test-mphf`, `test-mphf-quotient`, `test-mphf-adversarial`, and `test-mphf-serialization` pass, with no false positives or negatives in the adversarial suite. `verify-mphf-hcltj` passes on an index rebuilt with a low threshold to force MPHF nodes.
