### PR TITLE
Add opt-in FastMod ModPolicy and PackedGlGh storage to MPHF - LTJ-24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,9 @@ set_target_properties(test-rank-support-glgh PROPERTIES CXX_STANDARD 17 CXX_STAN
 add_cltj_executable(test-rank-support-packed-glgh src/test/hashing/test_rank_support_packed_glgh.cpp test)
 set_target_properties(test-rank-support-packed-glgh PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-packed-glgh src/test/hashing/test_packed_glgh.cpp test)
+set_target_properties(test-packed-glgh PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(test-storage-strategies src/test/hashing/test_storage_strategies.cpp test)
 set_target_properties(test-storage-strategies PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_compile_options(cltj_core INTERFACE
 target_include_directories(cltj_core INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/lib/hybridBV/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/lib/fastmod/include
 )
 if(CLTJ_COLLECT_QUERY_STATS)
   target_compile_definitions(cltj_core INTERFACE CLTJ_COLLECT_QUERY_STATS_ENABLED)
@@ -276,3 +277,5 @@ add_cltj_executable(count-distinct-spo src/analysis/count_distinct_spo.cpp analy
 
 add_cltj_executable(bench-mphf-hashing src/bench/bench_mphf_hashing.cpp analysis)
 target_link_libraries(bench-mphf-hashing PRIVATE PTHASH)
+
+add_cltj_executable(bench-fastmod-micro src/bench/bench_fastmod_micro.cpp bench)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,9 @@ set_target_properties(test-rank-support-packed-glgh PROPERTIES CXX_STANDARD 17 C
 add_cltj_executable(test-packed-glgh src/test/hashing/test_packed_glgh.cpp test)
 set_target_properties(test-packed-glgh PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-packed-glgh-mphf src/test/hashing/test_packed_glgh_mphf.cpp test)
+set_target_properties(test-packed-glgh-mphf PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(test-storage-strategies src/test/hashing/test_storage_strategies.cpp test)
 set_target_properties(test-storage-strategies PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,9 @@ set_target_properties(test-trit-packed-array PROPERTIES CXX_STANDARD 17 CXX_STAN
 add_cltj_executable(test-rank-support-glgh src/test/hashing/test_rank_support_glgh.cpp test)
 set_target_properties(test-rank-support-glgh PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-rank-support-packed-glgh src/test/hashing/test_rank_support_packed_glgh.cpp test)
+set_target_properties(test-rank-support-packed-glgh PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(test-storage-strategies src/test/hashing/test_storage_strategies.cpp test)
 set_target_properties(test-storage-strategies PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,9 @@ set_target_properties(repro-mphf-build PROPERTIES CXX_STANDARD 17 CXX_STANDARD_R
 add_cltj_executable(test-mphf-serialization src/test/hashing/test_mphf_serialization.cpp test)
 set_target_properties(test-mphf-serialization PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+add_cltj_executable(test-modpolicy src/test/hashing/test_modpolicy.cpp test)
+set_target_properties(test-modpolicy PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
 add_cltj_executable(test-mphf-move src/test/hashing/test_mphf_move.cpp test)
 set_target_properties(test-mphf-move PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 

--- a/include/hashing/mod_policies.hpp
+++ b/include/hashing/mod_policies.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include <fastmod.h>
+
+namespace cltj {
+namespace hashing {
+namespace policies {
+
+struct NativeMod {
+    void bind(const std::array<uint64_t, 3>&) {}
+
+    uint64_t mod(uint64_t v, int, uint64_t p) const { return v % p; }
+};
+
+struct FastMod {
+    std::array<__uint128_t, 3> M_{};
+
+    void bind(const std::array<uint64_t, 3>& primes) {
+        for (int k = 0; k < 3; ++k) {
+            M_[k] = fastmod::computeM_u64(primes[k]);
+        }
+    }
+
+    uint64_t mod(uint64_t v, int k, uint64_t p) const {
+        return fastmod::fastmod_u64(v, M_[static_cast<size_t>(k)], p);
+    }
+};
+
+}  // namespace policies
+}  // namespace hashing
+}  // namespace cltj

--- a/include/hashing/mphf_bdz.hpp
+++ b/include/hashing/mphf_bdz.hpp
@@ -5,6 +5,7 @@
 #include "mphf_build_tracer.hpp"
 #include "storage/baseline.hpp"
 #include "key_policies.hpp"
+#include "mod_policies.hpp"
 #include <util/logger.hpp>
 #include <algorithm>
 #include <array>
@@ -64,14 +65,20 @@ struct SizeBreakdown {
  *
  * @tparam StorageStrategy  storage layout for G, B and rank support.
  * @tparam KeyPolicy        payload policy for membership / reconstruction.
+ * @tparam ModPolicy        modulo policy for the hash functions (native % or fastmod).
  */
-template <typename StorageStrategy = BaselineStorage, typename KeyPolicy = policies::NoKey>
+template <
+    typename StorageStrategy = BaselineStorage,
+    typename KeyPolicy = policies::NoKey,
+    typename ModPolicy = policies::NativeMod
+>
 class MPHF {
   private:
     // Core data structures
 
     StorageStrategy storage_;  // Unified storage for G array, bitvector B, and rank support
     KeyPolicy key_policy_;  // Policy for key-based payloads (membership, reconstruction)
+    [[no_unique_address]] ModPolicy mod_policy_;  // Modulo policy for the hash functions
     uint32_t m_;  // Size of G array (~1.23 * n)
     uint32_t n_;  // Number of keys
 
@@ -268,6 +275,7 @@ class MPHF {
         segment_starts_[0] = 0;
         segment_starts_[1] = primes_[0];
         segment_starts_[2] = primes_[0] + primes_[1];
+        mod_policy_.bind(primes_);
 
         // KeyPolicy only needs the hash parameters rebound before load().
         policies::KeyInitContext ctx{n_, primes_, multipliers_, biases_, segment_starts_, 0};
@@ -481,6 +489,7 @@ class MPHF {
         segment_starts_[1] = primes_[0];
         segment_starts_[2] = primes_[0] + primes_[1];
         m_ = static_cast<uint32_t>(primes_[0] + primes_[1] + primes_[2]);
+        mod_policy_.bind(primes_);
 
         // Use SplitMix64 mixer for better seed diversity
         uint64_t final_seed = splitmix64(SEED ^ static_cast<uint64_t>(retry_count));
@@ -714,7 +723,7 @@ class MPHF {
     uint32_t hash_function(uint32_t x, int k) const {
         const size_t i = static_cast<size_t>(k);
         const uint64_t r = primes_[i];
-        uint64_t mapped = (x * multipliers_[i]) % r;  // in [0, r)
+        uint64_t mapped = mod_policy_.mod(x * multipliers_[i], i, r);  // in [0, r)
         mapped += biases_[i];
         if (mapped >= r)
             mapped -= r;  // single correction instead of modulo

--- a/include/hashing/storage/packed_glgh.hpp
+++ b/include/hashing/storage/packed_glgh.hpp
@@ -1,0 +1,105 @@
+#pragma once
+#include "strategy.hpp"
+#include "rank_support_packed_glgh.hpp"
+#include <sdsl/int_vector.hpp>
+#include <sdsl/structure_tree.hpp>
+#include <sdsl/util.hpp>
+
+namespace cltj {
+namespace hashing {
+
+/**
+ * @brief Packed GlGh storage strategy.
+ *
+ * Stores G as a single int_vector<2> where each vertex takes 2 contiguous bits.
+ * G[v] = 3 is the unassigned sentinel.
+ * B is implicit: B[v] = (G[v] != 3).
+ *
+ * Space: 2.81 bits/key (same as GlGhStorage, but 1 access per probe instead of 2).
+ */
+class PackedGlGhStorage : public StorageStrategy<PackedGlGhStorage> {
+  private:
+    sdsl::int_vector<2> G_;  // G[v] in {0,1,2,3}, 2 bits per vertex
+    rank_support_packed_glgh<> rank_B_;  // Rank for B = (G[v] != 3), on-the-fly
+    uint32_t m_ = 0;
+
+  public:
+    PackedGlGhStorage() = default;
+
+    PackedGlGhStorage(PackedGlGhStorage&& o) noexcept
+        : G_(std::move(o.G_)), rank_B_(std::move(o.rank_B_)), m_(o.m_) {
+        rank_B_.set_vector(&G_);
+    }
+
+    PackedGlGhStorage& operator=(PackedGlGhStorage&& o) noexcept {
+        if (this != &o) {
+            G_ = std::move(o.G_);
+            rank_B_ = std::move(o.rank_B_);
+            m_ = o.m_;
+            rank_B_.set_vector(&G_);
+        }
+        return *this;
+    }
+
+    uint32_t g_get(uint32_t vertex) const {
+        if (vertex >= m_)
+            return 3;
+        return G_[vertex];
+    }
+
+    void g_set(uint32_t vertex, uint32_t value) {
+        if (vertex < m_)
+            G_[vertex] = value;
+    }
+
+    bool is_vertex_occupied(uint32_t vertex) const {
+        if (vertex >= m_)
+            return false;
+        return G_[vertex] != 3;
+    }
+
+    void initialize(uint32_t m) {
+        m_ = m;
+        G_ = sdsl::int_vector<2>(m, 3);
+    }
+
+    uint32_t m() const { return m_; }
+
+    void build_rank() { rank_B_ = rank_support_packed_glgh<>(&G_); }
+
+    uint32_t rank(uint32_t position) const {
+        if (position > m_)
+            position = m_;
+        return static_cast<uint32_t>(rank_B_.rank(position));
+    }
+
+    size_t serialize(std::ostream& out, sdsl::structure_tree_node* v, const std::string& name) const {
+        sdsl::structure_tree_node* child =
+            sdsl::structure_tree::add_child(v, name, sdsl::util::class_name(*this));
+        size_t written_bytes = 0;
+        written_bytes += G_.serialize(out, child, "G_");
+        written_bytes += rank_B_.serialize(out, child, "rank_B_");
+        written_bytes += sdsl::write_member(m_, out, child, "m_");
+        sdsl::structure_tree::add_size(child, written_bytes);
+        return written_bytes;
+    }
+
+    void load(std::istream& in) {
+        G_.load(in);
+        rank_B_.load(in, &G_);
+        sdsl::read_member(m_, in);
+    }
+
+    size_t size_in_bytes() const { return sdsl::size_in_bytes(G_) + rank_B_.size_in_bytes(); }
+
+    StorageSizeBreakdown get_size_breakdown() const {
+        StorageSizeBreakdown breakdown;
+        breakdown.g_bytes = sdsl::size_in_bytes(G_);
+        breakdown.used_pos_bytes = 0;
+        breakdown.rank_bytes = rank_B_.size_in_bytes();
+        return breakdown;
+    }
+};
+
+}  // namespace hashing
+}  // namespace cltj

--- a/include/hashing/storage/rank_support_packed_glgh.hpp
+++ b/include/hashing/storage/rank_support_packed_glgh.hpp
@@ -121,15 +121,14 @@ class rank_support_packed_glgh
                 m_basic_block = sdsl::int_vector<64>(2,0);   // resize structure for basic_blocks
                 return;
             }
-            // One superblock per 512 vertices (8 logical words), same as GlGh.
-            // capacity() is bits = 2*vertices, so >>10 gives vertices/512.
-            size_type basic_block_size = ((g->capacity() >> 10)+1)<<1;
+            size_type num_words = m_g->capacity() >> 6;      // physical 64-bit words
+            size_type num_logical = (num_words + 1) >> 1;    // 64-vertex logical words
+            // Same metadata sizing as GlGh, but counted in logical words.
+            size_type basic_block_size = ((num_logical >> 3)+1)<<1;
             m_basic_block.resize(basic_block_size);   // resize structure for basic_blocks
             if (m_basic_block.empty())
                 return;
             const uint64_t* g_data = m_g->data();
-            size_type num_words = m_g->capacity() >> 6;      // physical 64-bit words
-            size_type num_logical = (num_words + 1) >> 1;    // 64-vertex logical words
             size_type i, j=0;
             m_basic_block[0] = m_basic_block[1] = 0;
 

--- a/include/hashing/storage/rank_support_packed_glgh.hpp
+++ b/include/hashing/storage/rank_support_packed_glgh.hpp
@@ -1,0 +1,213 @@
+/* sdsl - succinct data structures library
+    Copyright (C) 2008-2013 Simon Gog
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/ .
+
+    MODIFIED VERSION: Based on rank_support_v.hpp from SDSL.
+    Modified to support on-the-fly bitvector computation from Gl and Gh bitvectors
+    for the GlGhStorage MPHF strategy. The bitvector B is computed as B[v] = ~(Gl[v] & Gh[v])
+    on-the-fly instead of being stored explicitly.
+*/
+/*! \file rank_support_glgh.hpp
+    \brief rank_support_glgh.hpp contains rank_support_glgh (modified from rank_support_v).
+    \author Based on work by Simon Gog, modified for on-the-fly bitvector computation
+*/
+// clang-format off
+#ifndef INCLUDED_CLTJ_RANK_SUPPORT_GLGH
+#define INCLUDED_CLTJ_RANK_SUPPORT_GLGH
+
+#include <sdsl/rank_support.hpp>
+#include <sdsl/bit_vectors.hpp>
+#include <sdsl/int_vector.hpp>
+#include <sdsl/bits.hpp>
+
+//! Namespace for the compactLTJ library.
+namespace cltj {
+namespace hashing {
+
+
+//! A rank structure for on-the-fly bitvector computation (based on rank_support_v by Sebastiano Vigna)
+/*! \par Space complexity
+ *  \f$ 0.25n\f$ for a bit vector of length n bits.
+ *
+ * The superblock size is 512. Each superblock is subdivided into 512/64 = 8
+ * blocks. So absolute counts for the superblock add 64/512 bits on top of each
+ * supported bit. Since the first of the 8 relative count values is 0, we can
+ * fit the remaining 7 (each of width log(512)=9) in a 64bit word. The relative
+ * counts add another 64/512 bits on top of each supported bit.
+ * In total this results in 128/512=25% overhead.
+ *
+ * This modified version computes the bitvector B on-the-fly from Gl and Gh:
+ * B[v] = ~(Gl[v] & Gh[v])
+ *
+ * \tparam t_b       Bit pattern `0`,`1`,`10`,`01` which should be ranked.
+ * \tparam t_pat_len Length of the bit pattern.
+ *
+ * \par Reference
+ *    Sebastiano Vigna:
+ *    Broadword Implementation of Rank/Select Queries.
+ *    WEA 2008: 154-168
+ */
+template<uint8_t t_b=1, uint8_t t_pat_len=1>
+class rank_support_glgh : public sdsl::rank_support
+{
+    private:
+        // For the GlGh MPHF storage we only need rank1 support.
+        static_assert(t_b == 1u && t_pat_len == 1u,
+                      "rank_support_glgh only supports rank1 (t_b=1, t_pat_len=1)");
+    public:
+        typedef sdsl::bit_vector                          bit_vector_type;
+        typedef sdsl::rank_support_trait<t_b, t_pat_len>  trait_type;
+        enum { bit_pat = t_b };
+        enum { bit_pat_len = t_pat_len };
+    private:
+        // basic block for interleaved storage of superblockrank and blockrank
+        sdsl::int_vector<64> m_basic_block;
+        // Pointers to Gl and Gh bitvectors from which B is computed on-the-fly.
+        const bit_vector_type* m_gl = nullptr;
+        const bit_vector_type* m_gh = nullptr;
+
+        static inline uint64_t compute_b_word(uint64_t gl_word, uint64_t gh_word) {
+            return ~(gl_word & gh_word);
+        }
+    public:
+        explicit rank_support_glgh(const bit_vector_type* gl = nullptr,
+                                   const bit_vector_type* gh = nullptr) {
+            // m_v (from base) will point to Gl; we never store B explicitly.
+            m_gl = gl;
+            m_gh = gh;
+            m_v  = gl;
+
+            if (gl == nullptr || gh == nullptr) {
+                return;
+            } else if (gl->empty()) {
+                m_basic_block = sdsl::int_vector<64>(2,0);   // resize structure for basic_blocks
+                return;
+            }
+            size_type basic_block_size = ((gl->capacity() >> 9)+1)<<1;
+            m_basic_block.resize(basic_block_size);   // resize structure for basic_blocks
+            if (m_basic_block.empty())
+                return;
+            const uint64_t* gl_data = m_gl->data();
+            const uint64_t* gh_data = m_gh->data();
+            size_type i, j=0;
+            m_basic_block[0] = m_basic_block[1] = 0;
+
+            // First word of B: B_word = ~(Gl_word & Gh_word).
+            uint64_t first_gl = *gl_data;
+            uint64_t first_gh = *gh_data;
+            uint64_t b_word   = compute_b_word(first_gl, first_gh);
+            uint64_t sum      = sdsl::bits::cnt(b_word);
+            uint64_t second_level_cnt = 0;
+            for (i = 1; i < (m_gl->capacity()>>6) ; ++i) {
+                uint64_t word_gl = gl_data[i];
+                uint64_t word_gh = gh_data[i];
+                b_word = compute_b_word(word_gl, word_gh);
+                if (!(i&0x7)) {// if i%8==0
+                    j += 2;
+                    m_basic_block[j-1] = second_level_cnt;
+                    m_basic_block[j] 	= m_basic_block[j-2] + sum;
+                    second_level_cnt = sum = 0;
+                } else {
+                    second_level_cnt |= sum<<(63-9*(i&0x7));//  54, 45, 36, 27, 18, 9, 0
+                }
+                sum += sdsl::bits::cnt(b_word);
+            }
+            if (i&0x7) { // if i%8 != 0
+                second_level_cnt |= sum << (63-9*(i&0x7));
+                m_basic_block[j+1] = second_level_cnt;
+            } else { // if i%8 == 0
+                j += 2;
+                m_basic_block[j-1] = second_level_cnt;
+                m_basic_block[j]   = m_basic_block[j-2] + sum;
+                m_basic_block[j+1] = 0;
+            }
+        }
+
+        rank_support_glgh(const rank_support_glgh&)  = default;
+        rank_support_glgh(rank_support_glgh&&) = default;
+        rank_support_glgh& operator=(const rank_support_glgh&) = default;
+        rank_support_glgh& operator=(rank_support_glgh&&) = default;
+
+
+        size_type rank(size_type idx) const override {
+            assert(m_gl != nullptr && m_gh != nullptr);
+            assert(idx <= m_gl->size());
+            const uint64_t* p = m_basic_block.data()
+                                + ((idx>>8)&0xFFFFFFFFFFFFFFFEULL); // (idx/512)*2
+            size_type result = *p + ((*(p+1)>>(63 - 9*((idx&0x1FF)>>6)))&0x1FF);
+            if (idx&0x3F) { // if (idx%64)!=0
+                // Add contribution of the remaining bits in the current 64-bit word.
+                size_type word_idx = idx >> 6;
+                uint8_t  offset    = idx & 0x3F;
+                const uint64_t* gl_data = m_gl->data();
+                const uint64_t* gh_data = m_gh->data();
+                uint64_t b_word = compute_b_word(gl_data[word_idx], gh_data[word_idx]);
+                uint64_t mask   = sdsl::bits::lo_set[offset];
+                result += sdsl::bits::cnt(b_word & mask);
+            }
+            return result;
+        }
+
+        inline size_type operator()(size_type idx)const {
+            return rank(idx);
+        }
+
+        size_type size()const {
+            return m_gl ? m_gl->size() : 0;
+        }
+
+        size_type size_in_bytes() const {
+            return sdsl::size_in_bytes(m_basic_block);
+        }
+
+        size_type serialize(std::ostream& out, sdsl::structure_tree_node* v=nullptr,
+                            std::string name="")const {
+            size_type written_bytes = 0;
+            sdsl::structure_tree_node* child = sdsl::structure_tree::add_child(
+                v, name, sdsl::util::class_name(*this)
+            );
+            written_bytes += m_basic_block.serialize(out, child,
+                             "cumulative_counts");
+            sdsl::structure_tree::add_size(child, written_bytes);
+            return written_bytes;
+        }
+
+        void load(std::istream& in, const sdsl::int_vector<1>* v=nullptr) {
+            set_vector(v);
+            m_basic_block.load(in);
+        }
+
+        void set_vector(const bit_vector_type* v=nullptr) override {
+            // For compatibility with the base interface, treat v as Gl.
+            m_gl = v;
+            m_v  = v;
+        }
+
+        void set_gh(const bit_vector_type* gh=nullptr) {
+            m_gh = gh;
+        }
+
+        void swap(rank_support_glgh& rs) {
+            if (this != &rs) { // if rs and _this_ are not the same object
+                m_basic_block.swap(rs.m_basic_block);
+            }
+        }
+};
+
+}  // namespace hashing
+}  // namespace cltj
+
+// clang-format on
+#endif  // end file

--- a/include/hashing/storage/rank_support_packed_glgh.hpp
+++ b/include/hashing/storage/rank_support_packed_glgh.hpp
@@ -15,20 +15,19 @@
     along with this program.  If not, see http://www.gnu.org/licenses/ .
 
     MODIFIED VERSION: Based on rank_support_v.hpp from SDSL.
-    Modified to support on-the-fly bitvector computation from Gl and Gh bitvectors
-    for the GlGhStorage MPHF strategy. The bitvector B is computed as B[v] = ~(Gl[v] & Gh[v])
-    on-the-fly instead of being stored explicitly.
+    Modified to support on-the-fly bitvector computation from a packed
+    int_vector<2> for the PackedGlGhStorage MPHF strategy. The bitvector B
+    is computed as B[v] = (G[v] != 3) on-the-fly instead of being stored
+    explicitly.
 */
-/*! \file rank_support_glgh.hpp
-    \brief rank_support_glgh.hpp contains rank_support_glgh (modified from rank_support_v).
+/*! \file rank_support_packed_glgh.hpp
+    \brief rank_support_packed_glgh.hpp contains rank_support_packed_glgh.
     \author Based on work by Simon Gog, modified for on-the-fly bitvector computation
 */
 // clang-format off
-#ifndef INCLUDED_CLTJ_RANK_SUPPORT_GLGH
-#define INCLUDED_CLTJ_RANK_SUPPORT_GLGH
+#ifndef INCLUDED_CLTJ_RANK_SUPPORT_PACKED_GLGH
+#define INCLUDED_CLTJ_RANK_SUPPORT_PACKED_GLGH
 
-#include <sdsl/rank_support.hpp>
-#include <sdsl/bit_vectors.hpp>
 #include <sdsl/int_vector.hpp>
 #include <sdsl/bits.hpp>
 
@@ -60,60 +59,50 @@ namespace hashing {
  *    WEA 2008: 154-168
  */
 template<uint8_t t_b=1, uint8_t t_pat_len=1>
-class rank_support_glgh : public sdsl::rank_support
+class rank_support_packed_glgh
 {
     private:
-        // For the GlGh MPHF storage we only need rank1 support.
+        // For the PackedGlGh MPHF storage we only need rank1 support.
         static_assert(t_b == 1u && t_pat_len == 1u,
-                      "rank_support_glgh only supports rank1 (t_b=1, t_pat_len=1)");
+                      "rank_support_packed_glgh only supports rank1");
     public:
-        typedef sdsl::bit_vector                          bit_vector_type;
-        typedef sdsl::rank_support_trait<t_b, t_pat_len>  trait_type;
+        typedef sdsl::int_vector<2>                       packed_vector_type;
         enum { bit_pat = t_b };
         enum { bit_pat_len = t_pat_len };
+        using size_type = size_t;
     private:
         // basic block for interleaved storage of superblockrank and blockrank
         sdsl::int_vector<64> m_basic_block;
-        // Pointers to Gl and Gh bitvectors from which B is computed on-the-fly.
-        const bit_vector_type* m_gl = nullptr;
-        const bit_vector_type* m_gh = nullptr;
+        // Pointer to the int_vector<2> from which B is computed on-the-fly.
+        const packed_vector_type* m_g = nullptr;
 
-        static inline uint64_t compute_b_word(uint64_t gl_word, uint64_t gh_word) {
-            return ~(gl_word & gh_word);
+        static inline uint64_t compute_b_word(uint64_t W) {
+            constexpr uint64_t EVEN = 0x5555555555555555ULL;
+            return (W & (W >> 1) & EVEN) ^ EVEN;
         }
     public:
-        explicit rank_support_glgh(const bit_vector_type* gl = nullptr,
-                                   const bit_vector_type* gh = nullptr) {
-            // m_v (from base) will point to Gl; we never store B explicitly.
-            m_gl = gl;
-            m_gh = gh;
-            m_v  = gl;
+        explicit rank_support_packed_glgh(const packed_vector_type* g = nullptr) {
+            m_g = g;
 
-            if (gl == nullptr || gh == nullptr) {
+            if (g == nullptr) {
                 return;
-            } else if (gl->empty()) {
+            } else if (g->empty()) {
                 m_basic_block = sdsl::int_vector<64>(2,0);   // resize structure for basic_blocks
                 return;
             }
-            size_type basic_block_size = ((gl->capacity() >> 9)+1)<<1;
+            size_type basic_block_size = ((g->capacity() >> 9)+1)<<1;
             m_basic_block.resize(basic_block_size);   // resize structure for basic_blocks
             if (m_basic_block.empty())
                 return;
-            const uint64_t* gl_data = m_gl->data();
-            const uint64_t* gh_data = m_gh->data();
+            const uint64_t* g_data = m_g->data();
             size_type i, j=0;
             m_basic_block[0] = m_basic_block[1] = 0;
 
-            // First word of B: B_word = ~(Gl_word & Gh_word).
-            uint64_t first_gl = *gl_data;
-            uint64_t first_gh = *gh_data;
-            uint64_t b_word   = compute_b_word(first_gl, first_gh);
-            uint64_t sum      = sdsl::bits::cnt(b_word);
+            // First word of B.
+            uint64_t sum = sdsl::bits::cnt(compute_b_word(*g_data));
             uint64_t second_level_cnt = 0;
-            for (i = 1; i < (m_gl->capacity()>>6) ; ++i) {
-                uint64_t word_gl = gl_data[i];
-                uint64_t word_gh = gh_data[i];
-                b_word = compute_b_word(word_gl, word_gh);
+            for (i = 1; i < (m_g->capacity()>>6) ; ++i) {
+                uint64_t b_word = compute_b_word(g_data[i]);
                 if (!(i&0x7)) {// if i%8==0
                     j += 2;
                     m_basic_block[j-1] = second_level_cnt;
@@ -135,26 +124,24 @@ class rank_support_glgh : public sdsl::rank_support
             }
         }
 
-        rank_support_glgh(const rank_support_glgh&)  = default;
-        rank_support_glgh(rank_support_glgh&&) = default;
-        rank_support_glgh& operator=(const rank_support_glgh&) = default;
-        rank_support_glgh& operator=(rank_support_glgh&&) = default;
+        rank_support_packed_glgh(const rank_support_packed_glgh&)  = default;
+        rank_support_packed_glgh(rank_support_packed_glgh&&) = default;
+        rank_support_packed_glgh& operator=(const rank_support_packed_glgh&) = default;
+        rank_support_packed_glgh& operator=(rank_support_packed_glgh&&) = default;
 
 
-        size_type rank(size_type idx) const override {
-            assert(m_gl != nullptr && m_gh != nullptr);
-            assert(idx <= m_gl->size());
+        size_type rank(size_type idx) const {
+            assert(m_g != nullptr);
+            assert(idx <= m_g->size());
             const uint64_t* p = m_basic_block.data()
-                                + ((idx>>8)&0xFFFFFFFFFFFFFFFEULL); // (idx/512)*2
-            size_type result = *p + ((*(p+1)>>(63 - 9*((idx&0x1FF)>>6)))&0x1FF);
-            if (idx&0x3F) { // if (idx%64)!=0
+                                + ((idx>>7)&0xFFFFFFFFFFFFFFFEULL); // (idx/256)*2
+            size_type result = *p + ((*(p+1)>>(63 - 9*((idx&0xFF)>>5)))&0x1FF);
+            if (idx&0x1F) { // if (idx%32)!=0
                 // Add contribution of the remaining bits in the current 64-bit word.
-                size_type word_idx = idx >> 6;
-                uint8_t  offset    = idx & 0x3F;
-                const uint64_t* gl_data = m_gl->data();
-                const uint64_t* gh_data = m_gh->data();
-                uint64_t b_word = compute_b_word(gl_data[word_idx], gh_data[word_idx]);
-                uint64_t mask   = sdsl::bits::lo_set[offset];
+                size_type word_idx = idx >> 5;
+                uint8_t  offset    = idx & 0x1F;
+                uint64_t b_word     = compute_b_word(m_g->data()[word_idx]);
+                uint64_t mask      = sdsl::bits::lo_set[2 * offset];
                 result += sdsl::bits::cnt(b_word & mask);
             }
             return result;
@@ -165,7 +152,7 @@ class rank_support_glgh : public sdsl::rank_support
         }
 
         size_type size()const {
-            return m_gl ? m_gl->size() : 0;
+            return m_g ? m_g->size() : 0;
         }
 
         size_type size_in_bytes() const {
@@ -184,22 +171,16 @@ class rank_support_glgh : public sdsl::rank_support
             return written_bytes;
         }
 
-        void load(std::istream& in, const sdsl::int_vector<1>* v=nullptr) {
-            set_vector(v);
+        void load(std::istream& in, const packed_vector_type* g=nullptr) {
+            m_g = g;
             m_basic_block.load(in);
         }
 
-        void set_vector(const bit_vector_type* v=nullptr) override {
-            // For compatibility with the base interface, treat v as Gl.
-            m_gl = v;
-            m_v  = v;
+        void set_vector(const packed_vector_type* g=nullptr) {
+            m_g = g;
         }
 
-        void set_gh(const bit_vector_type* gh=nullptr) {
-            m_gh = gh;
-        }
-
-        void swap(rank_support_glgh& rs) {
+        void swap(rank_support_packed_glgh& rs) {
             if (this != &rs) { // if rs and _this_ are not the same object
                 m_basic_block.swap(rs.m_basic_block);
             }

--- a/include/hashing/storage/rank_support_packed_glgh.hpp
+++ b/include/hashing/storage/rank_support_packed_glgh.hpp
@@ -47,8 +47,17 @@ namespace hashing {
  * counts add another 64/512 bits on top of each supported bit.
  * In total this results in 128/512=25% overhead.
  *
- * This modified version computes the bitvector B on-the-fly from Gl and Gh:
- * B[v] = ~(Gl[v] & Gh[v])
+ * This modified version computes the bitvector B on-the-fly from a packed
+ * int_vector<2> (instead of two separate bitvectors Gl and Gh). Each vertex
+ * takes 2 contiguous bits; a vertex is occupied (B[v]=1) when G[v] != 3.
+ * Detection across 32 vertices per 64-bit word uses SWAR:
+ *
+ *   compute_b_word(W) = (W & (W>>1) & 0x5555...) ^ 0x5555...
+ *
+ * Because each word covers 32 vertices instead of 64, all vertex-index
+ * constants in rank() are halved vs the GlGh version (superblock 256
+ * vertices, block 32 vertices, idx>>5 instead of idx>>6, etc.). The
+ * metadata layout (superblocks every 8 words, 9-bit deltas) is unchanged.
  *
  * \tparam t_b       Bit pattern `0`,`1`,`10`,`01` which should be ranked.
  * \tparam t_pat_len Length of the bit pattern.
@@ -76,6 +85,12 @@ class rank_support_packed_glgh
         // Pointer to the int_vector<2> from which B is computed on-the-fly.
         const packed_vector_type* m_g = nullptr;
 
+        /**
+         * @brief Compute the occupancy word for 32 vertices packed in 2-bit lanes.
+         *
+         * Returns a 64-bit mask where bit 2k = 1 iff lane k is occupied
+         * (G[k] != 3). This is the packed equivalent of ~(gl_word & gh_word) in GlGh
+         */
         static inline uint64_t compute_b_word(uint64_t W) {
             constexpr uint64_t EVEN = 0x5555555555555555ULL;
             return (W & (W >> 1) & EVEN) ^ EVEN;
@@ -130,6 +145,14 @@ class rank_support_packed_glgh
         rank_support_packed_glgh& operator=(rank_support_packed_glgh&&) = default;
 
 
+        /**
+         * @brief Rank of occupied vertices up to idx.
+         *
+         * Same Vigna superblock/block scheme as rank_support_glgh, but
+         * adapted for 32 vertices per 64-bit word: superblock is 256
+         * vertices (8 words), block is 32 vertices (1 word), and the
+         * partial-word mask uses 2*offset bits per lane.
+         */
         size_type rank(size_type idx) const {
             assert(m_g != nullptr);
             assert(idx <= m_g->size());

--- a/include/hashing/storage/rank_support_packed_glgh.hpp
+++ b/include/hashing/storage/rank_support_packed_glgh.hpp
@@ -54,10 +54,11 @@ namespace hashing {
  *
  *   compute_b_word(W) = (W & (W>>1) & 0x5555...) ^ 0x5555...
  *
- * Because each word covers 32 vertices instead of 64, all vertex-index
- * constants in rank() are halved vs the GlGh version (superblock 256
- * vertices, block 32 vertices, idx>>5 instead of idx>>6, etc.). The
- * metadata layout (superblocks every 8 words, 9-bit deltas) is unchanged.
+ * A 64-bit word holds 32 vertices (2 bits each), so a 64-vertex logical
+ * word spans two consecutive physical words. The rank keeps the exact GlGh
+ * metadata (superblock 512 vertices, block 64 vertices, 9-bit deltas) by
+ * treating two physical words as one logical word, so the rank metadata
+ * stays the same size as GlGh (no space regression: 2.81 b/k total).
  *
  * \tparam t_b       Bit pattern `0`,`1`,`10`,`01` which should be ranked.
  * \tparam t_pat_len Length of the bit pattern.
@@ -95,6 +96,21 @@ class rank_support_packed_glgh
             constexpr uint64_t EVEN = 0x5555555555555555ULL;
             return (W & (W >> 1) & EVEN) ^ EVEN;
         }
+
+        /**
+         * @brief Count occupied vertices in a logical word (64 vertices).
+         *
+         * A logical word is two consecutive physical 64-bit words. The second
+         * may be absent when the array has an odd physical word count; then only
+         * the first contributes (matches GlGh's handling of the trailing word).
+         */
+        static inline uint64_t logical_cnt(const uint64_t* g, size_type lw,
+                                           size_type num_words) {
+            uint64_t c = sdsl::bits::cnt(compute_b_word(g[2 * lw]));
+            if (2 * lw + 1 < num_words)
+                c += sdsl::bits::cnt(compute_b_word(g[2 * lw + 1]));
+            return c;
+        }
     public:
         explicit rank_support_packed_glgh(const packed_vector_type* g = nullptr) {
             m_g = g;
@@ -105,19 +121,22 @@ class rank_support_packed_glgh
                 m_basic_block = sdsl::int_vector<64>(2,0);   // resize structure for basic_blocks
                 return;
             }
-            size_type basic_block_size = ((g->capacity() >> 9)+1)<<1;
+            // One superblock per 512 vertices (8 logical words), same as GlGh.
+            // capacity() is bits = 2*vertices, so >>10 gives vertices/512.
+            size_type basic_block_size = ((g->capacity() >> 10)+1)<<1;
             m_basic_block.resize(basic_block_size);   // resize structure for basic_blocks
             if (m_basic_block.empty())
                 return;
             const uint64_t* g_data = m_g->data();
+            size_type num_words = m_g->capacity() >> 6;      // physical 64-bit words
+            size_type num_logical = (num_words + 1) >> 1;    // 64-vertex logical words
             size_type i, j=0;
             m_basic_block[0] = m_basic_block[1] = 0;
 
-            // First word of B.
-            uint64_t sum = sdsl::bits::cnt(compute_b_word(*g_data));
+            // First logical word.
+            uint64_t sum = logical_cnt(g_data, 0, num_words);
             uint64_t second_level_cnt = 0;
-            for (i = 1; i < (m_g->capacity()>>6) ; ++i) {
-                uint64_t b_word = compute_b_word(g_data[i]);
+            for (i = 1; i < num_logical ; ++i) {
                 if (!(i&0x7)) {// if i%8==0
                     j += 2;
                     m_basic_block[j-1] = second_level_cnt;
@@ -126,7 +145,7 @@ class rank_support_packed_glgh
                 } else {
                     second_level_cnt |= sum<<(63-9*(i&0x7));//  54, 45, 36, 27, 18, 9, 0
                 }
-                sum += sdsl::bits::cnt(b_word);
+                sum += logical_cnt(g_data, i, num_words);
             }
             if (i&0x7) { // if i%8 != 0
                 second_level_cnt |= sum << (63-9*(i&0x7));
@@ -148,24 +167,30 @@ class rank_support_packed_glgh
         /**
          * @brief Rank of occupied vertices up to idx.
          *
-         * Same Vigna superblock/block scheme as rank_support_glgh, but
-         * adapted for 32 vertices per 64-bit word: superblock is 256
-         * vertices (8 words), block is 32 vertices (1 word), and the
-         * partial-word mask uses 2*offset bits per lane.
+         * Same Vigna superblock/block scheme and constants as rank_support_glgh
+         * (superblock 512 vertices, block 64 vertices). A 64-vertex logical word
+         * is two physical words; the partial count reads the first physical word
+         * and, if idx falls past its 32 vertices, the second one too. Masks use
+         * 2*offset bits because each vertex occupies a 2-bit lane.
          */
         size_type rank(size_type idx) const {
             assert(m_g != nullptr);
             assert(idx <= m_g->size());
             const uint64_t* p = m_basic_block.data()
-                                + ((idx>>7)&0xFFFFFFFFFFFFFFFEULL); // (idx/256)*2
-            size_type result = *p + ((*(p+1)>>(63 - 9*((idx&0xFF)>>5)))&0x1FF);
-            if (idx&0x1F) { // if (idx%32)!=0
-                // Add contribution of the remaining bits in the current 64-bit word.
-                size_type word_idx = idx >> 5;
-                uint8_t  offset    = idx & 0x1F;
-                uint64_t b_word     = compute_b_word(m_g->data()[word_idx]);
-                uint64_t mask      = sdsl::bits::lo_set[2 * offset];
-                result += sdsl::bits::cnt(b_word & mask);
+                                + ((idx>>8)&0xFFFFFFFFFFFFFFFEULL); // (idx/512)*2
+            size_type result = *p + ((*(p+1)>>(63 - 9*((idx&0x1FF)>>6)))&0x1FF);
+            if (idx&0x3F) { // if (idx%64)!=0
+                const uint64_t* g = m_g->data();
+                size_type lw     = idx >> 6;    // logical word (64 vertices, 2 physical words)
+                uint8_t   offset = idx & 0x3F;   // vertices into the logical word (0..63)
+                uint64_t  w0     = compute_b_word(g[2 * lw]);
+                if (offset <= 32) {
+                    result += sdsl::bits::cnt(w0 & sdsl::bits::lo_set[2 * offset]);
+                } else {
+                    uint64_t w1 = compute_b_word(g[2 * lw + 1]);
+                    result += sdsl::bits::cnt(w0)
+                            + sdsl::bits::cnt(w1 & sdsl::bits::lo_set[2 * (offset - 32)]);
+                }
             }
             return result;
         }
@@ -195,7 +220,7 @@ class rank_support_packed_glgh
         }
 
         void load(std::istream& in, const packed_vector_type* g=nullptr) {
-            m_g = g;
+            set_vector(g);
             m_basic_block.load(in);
         }
 

--- a/src/bench/bench_fastmod_micro.cpp
+++ b/src/bench/bench_fastmod_micro.cpp
@@ -1,0 +1,203 @@
+// Micro-benchmark: fastmod_u64 vs native % in the MPHF hash regime.
+// Measures (a * x) % p with a < p < 2^32, x < 2^32, so a*x < 2^64.
+
+#include <hashing/mixers.hpp>
+#include <hashing/mphf_utils.hpp>
+
+#include <fastmod.h>
+
+#include <CLI11.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+using hrc = std::chrono::high_resolution_clock;
+
+struct Result {
+    std::string label;
+    long long total_ns;
+    size_t iterations;
+    double ns_per_op;
+};
+
+// Generate (p, a, x[]) combos in the real hash regime.
+// n_keys sizes the primes (p ~ 0.42*n), batch_size is how many combos we measure.
+// Keys go through premix32, same as the MPHF.
+struct Params {
+    uint64_t p;
+    uint64_t a;
+    std::vector<uint64_t> x;
+};
+
+std::vector<Params> gen_params(size_t n_keys, size_t batch_size, uint64_t seed) {
+    uint64_t target =
+        std::max<uint64_t>(3, static_cast<uint64_t>(std::ceil(1.25 * static_cast<double>(n_keys)) + 2) / 3);
+    uint64_t base = cltj::hashing::next_prime(target);
+
+    std::mt19937_64 rng(seed);
+    std::vector<Params> params;
+    params.reserve(batch_size);
+
+    uint64_t p = base;
+    for (size_t i = 0; i < batch_size; ++i) {
+        Params hp;
+        hp.p = p;
+
+        std::uniform_int_distribution<uint64_t> distA(1, p - 1);
+        hp.a = distA(rng);
+
+        hp.x.resize(n_keys);
+        std::uniform_int_distribution<uint32_t> distKey;
+        for (size_t j = 0; j < n_keys; ++j) {
+            hp.x[j] = cltj::hashing::premix32(distKey(rng));
+        }
+
+        params.push_back(hp);
+        p = cltj::hashing::next_prime(p + 1);
+    }
+
+    return params;
+}
+
+Result bench_native(const std::vector<Params>& params) {
+    auto start = hrc::now();
+
+    volatile uint64_t sink = 0;
+    size_t ops = 0;
+
+    for (const auto& hp : params) {
+        uint64_t a = hp.a;
+        uint64_t p_val = hp.p;
+        for (uint64_t x : hp.x) {
+            uint64_t r = (x * a) % p_val;
+            sink ^= r;
+            ++ops;
+        }
+    }
+
+    auto end = hrc::now();
+    (void)sink;
+
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+    return {"native %", ns, ops, static_cast<double>(ns) / static_cast<double>(ops)};
+}
+
+Result bench_fastmod(const std::vector<Params>& params) {
+    std::vector<__uint128_t> M;
+    M.reserve(params.size());
+    for (const auto& hp : params) {
+        M.push_back(fastmod::computeM_u64(hp.p));
+    }
+
+    auto start = hrc::now();
+
+    volatile uint64_t sink = 0;
+    size_t ops = 0;
+
+    for (size_t i = 0; i < params.size(); ++i) {
+        uint64_t a = params[i].a;
+        uint64_t p_val = params[i].p;
+        __uint128_t m_val = M[i];
+        for (uint64_t x : params[i].x) {
+            uint64_t prod = x * a;
+            uint64_t r = fastmod::fastmod_u64(prod, m_val, p_val);
+            sink ^= r;
+            ++ops;
+        }
+    }
+
+    auto end = hrc::now();
+    (void)sink;
+
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+    return {"fastmod_u64", ns, ops, static_cast<double>(ns) / static_cast<double>(ops)};
+}
+
+bool verify(const std::vector<Params>& params) {
+    std::vector<__uint128_t> M;
+    M.reserve(params.size());
+    for (const auto& hp : params) {
+        M.push_back(fastmod::computeM_u64(hp.p));
+    }
+
+    size_t checked = 0;
+    for (size_t i = 0; i < params.size(); ++i) {
+        uint64_t a = params[i].a;
+        uint64_t p_val = params[i].p;
+        __uint128_t m_val = M[i];
+        for (uint64_t x : params[i].x) {
+            uint64_t expected = (x * a) % p_val;
+            uint64_t got = fastmod::fastmod_u64(x * a, m_val, p_val);
+            if (expected != got) {
+                std::cerr << "MISMATCH: a=" << a << " x=" << x << " p=" << p_val << " native=" << expected
+                          << " fastmod=" << got << std::endl;
+                return false;
+            }
+            ++checked;
+        }
+    }
+
+    std::cout << "Correctness: " << checked << " ops, all equal." << std::endl;
+    return true;
+}
+
+struct Config {
+    size_t n = 10'000'000;
+    size_t batch = 10;
+    uint64_t seed = 42;
+};
+
+int run(const Config& cfg) {
+    std::cout << "=== fastmod_u64 micro-bench ===\n"
+              << "n=" << cfg.n << " batch=" << cfg.batch << " seed=" << cfg.seed << std::endl;
+
+    // Sanity: correctness on small batch first.
+    {
+        auto p = gen_params(1000, 2, cfg.seed);
+        if (!verify(p)) {
+            std::cerr << "FAIL" << std::endl;
+            return 1;
+        }
+    }
+
+    auto params = gen_params(cfg.n, cfg.batch, cfg.seed);
+    std::cout << "primes [" << params.front().p << ", " << params.back().p << "]" << std::endl;
+
+    auto native = bench_native(params);
+    std::cout << native.label << ": " << native.total_ns << " ns / " << native.iterations << " = "
+              << native.ns_per_op << " ns/op" << std::endl;
+
+    auto fm = bench_fastmod(params);
+    std::cout << fm.label << ": " << fm.total_ns << " ns / " << fm.iterations << " = " << fm.ns_per_op
+              << " ns/op" << std::endl;
+
+    double ratio = fm.ns_per_op / native.ns_per_op;
+    if (ratio < 1.0) {
+        std::cout << "fastmod wins: " << (1.0 / ratio) << "x faster" << std::endl;
+    } else {
+        std::cout << "native wins: " << ratio << "x faster" << std::endl;
+    }
+
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Config cfg;
+
+    CLI::App app{"fastmod_u64 vs native % micro-bench"};
+    app.add_option("-n", cfg.n, "Logical N (determines prime sizes)")->capture_default_str();
+    app.add_option("--batch", cfg.batch, "Number of (p,a,x[]) combos")->capture_default_str();
+    app.add_option("--seed", cfg.seed, "RNG seed")->capture_default_str();
+
+    CLI11_PARSE(app, argc, argv);
+    return run(cfg);
+}

--- a/src/bench/bench_fastmod_micro.cpp
+++ b/src/bench/bench_fastmod_micro.cpp
@@ -1,5 +1,17 @@
 // Micro-benchmark: fastmod_u64 vs native % in the MPHF hash regime.
 // Measures (a * x) % p with a < p < 2^32, x < 2^32, so a*x < 2^64.
+//
+// Design (why the bench is shaped this way):
+//  - p is runtime-variable per combo, so native % compiles to a real hardware divide.
+//    A compile-time-constant divisor would let the compiler emit its own magic-multiply
+//    (i.e. fastmod), making the comparison meaningless.
+//  - The key buffer is small and cache-resident: this bench isolates COMPUTE cost only.
+//    Out-of-cache / memory-bandwidth effects belong to the end-to-end --glgh benchmark,
+//    not here. `n` sizes the prime (matching the real regime), it does NOT size the buffer.
+//  - Anti-DCE via a single volatile store AFTER each timed loop, not one per iteration
+//    (a per-iteration volatile RMW adds fixed overhead that compresses the ratio).
+//  - Each measurement is warmed up, repeated `trials` times, and reported as the median;
+//    single-pass timings on this workload swing wildly (turbo ramp, scheduling).
 
 #include <hashing/mixers.hpp>
 #include <hashing/mphf_utils.hpp>
@@ -10,181 +22,204 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
-#include <random>
 #include <string>
+#include <random>
 #include <vector>
 
 namespace {
 
 using hrc = std::chrono::high_resolution_clock;
 
-struct Result {
-    std::string label;
-    long long total_ns;
-    size_t iterations;
-    double ns_per_op;
-};
-
-// Generate (p, a, x[]) combos in the real hash regime.
-// n_keys sizes the primes (p ~ 0.42*n), batch_size is how many combos we measure.
-// Keys go through premix32, same as the MPHF.
-struct Params {
+// One (p, a, key-buffer) combo. M is the fastmod reciprocal, precomputed once.
+struct Combo {
     uint64_t p;
     uint64_t a;
-    std::vector<uint64_t> x;
+    __uint128_t M;
+    std::vector<uint64_t> x;  // cache-resident buffer of premixed keys
 };
 
-std::vector<Params> gen_params(size_t n_keys, size_t batch_size, uint64_t seed) {
-    uint64_t target =
-        std::max<uint64_t>(3, static_cast<uint64_t>(std::ceil(1.25 * static_cast<double>(n_keys)) + 2) / 3);
-    uint64_t base = cltj::hashing::next_prime(target);
+// Prime magnitude for a logical N, mirroring MPHF::compute_target_segment:
+// m ~ 1.25*n slots split across 3 segments, so each prime ~ 0.42*n.
+uint64_t prime_base_for_n(size_t n) {
+    uint64_t target_m = static_cast<uint64_t>(std::ceil(1.25 * static_cast<double>(n)));
+    uint64_t target = std::max<uint64_t>(3, (target_m + 2) / 3);
+    return cltj::hashing::next_prime(target);
+}
 
+std::vector<Combo> gen_combos(size_t n_for_prime, size_t keys, size_t batch, uint64_t seed) {
     std::mt19937_64 rng(seed);
-    std::vector<Params> params;
-    params.reserve(batch_size);
+    std::vector<Combo> combos;
+    combos.reserve(batch);
 
-    uint64_t p = base;
-    for (size_t i = 0; i < batch_size; ++i) {
-        Params hp;
-        hp.p = p;
+    uint64_t p = prime_base_for_n(n_for_prime);
+    for (size_t i = 0; i < batch; ++i) {
+        Combo c;
+        c.p = p;
+        c.M = fastmod::computeM_u64(p);
 
         std::uniform_int_distribution<uint64_t> distA(1, p - 1);
-        hp.a = distA(rng);
+        c.a = distA(rng);
 
-        hp.x.resize(n_keys);
+        c.x.resize(keys);
         std::uniform_int_distribution<uint32_t> distKey;
-        for (size_t j = 0; j < n_keys; ++j) {
-            hp.x[j] = cltj::hashing::premix32(distKey(rng));
+        for (size_t j = 0; j < keys; ++j) {
+            c.x[j] = cltj::hashing::premix32(distKey(rng));
         }
 
-        params.push_back(hp);
+        combos.push_back(std::move(c));
         p = cltj::hashing::next_prime(p + 1);
     }
-
-    return params;
+    return combos;
 }
 
-Result bench_native(const std::vector<Params>& params) {
+// How many passes over the buffers to reach ~target_ops operations.
+size_t reps_for(size_t target_ops, size_t batch, size_t keys) {
+    size_t per_pass = batch * keys;
+    if (per_pass == 0)
+        return 1;
+    return std::max<size_t>((target_ops + per_pass - 1) / per_pass, 1);
+}
+
+// Per-rep salt (xor with the pass index) keeps xv < 2^32 while making each pass distinct,
+// so the compiler cannot hoist/CSE the inner work across the reps loop.
+double bench_native(const std::vector<Combo>& combos, size_t reps) {
+    uint64_t acc = 0;
     auto start = hrc::now();
-
-    volatile uint64_t sink = 0;
-    size_t ops = 0;
-
-    for (const auto& hp : params) {
-        uint64_t a = hp.a;
-        uint64_t p_val = hp.p;
-        for (uint64_t x : hp.x) {
-            uint64_t r = (x * a) % p_val;
-            sink ^= r;
-            ++ops;
+    for (size_t r = 0; r < reps; ++r) {
+        const uint64_t salt = static_cast<uint32_t>(r);
+        for (const auto& c : combos) {
+            const uint64_t a = c.a;
+            const uint64_t p = c.p;
+            for (uint64_t x : c.x) {
+                const uint64_t xv = x ^ salt;
+                acc ^= (xv * a) % p;
+            }
         }
     }
-
     auto end = hrc::now();
+    volatile uint64_t sink = acc;  // single anti-DCE store
     (void)sink;
 
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-    return {"native %", ns, ops, static_cast<double>(ns) / static_cast<double>(ops)};
+    double ns =
+        static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count());
+    double ops = static_cast<double>(reps) * static_cast<double>(combos.size()) *
+        static_cast<double>(combos.front().x.size());
+    return ns / ops;
 }
 
-Result bench_fastmod(const std::vector<Params>& params) {
-    std::vector<__uint128_t> M;
-    M.reserve(params.size());
-    for (const auto& hp : params) {
-        M.push_back(fastmod::computeM_u64(hp.p));
-    }
-
+double bench_fastmod(const std::vector<Combo>& combos, size_t reps) {
+    uint64_t acc = 0;
     auto start = hrc::now();
-
-    volatile uint64_t sink = 0;
-    size_t ops = 0;
-
-    for (size_t i = 0; i < params.size(); ++i) {
-        uint64_t a = params[i].a;
-        uint64_t p_val = params[i].p;
-        __uint128_t m_val = M[i];
-        for (uint64_t x : params[i].x) {
-            uint64_t prod = x * a;
-            uint64_t r = fastmod::fastmod_u64(prod, m_val, p_val);
-            sink ^= r;
-            ++ops;
+    for (size_t r = 0; r < reps; ++r) {
+        const uint64_t salt = static_cast<uint32_t>(r);
+        for (const auto& c : combos) {
+            const uint64_t a = c.a;
+            const uint64_t p = c.p;
+            const __uint128_t M = c.M;
+            for (uint64_t x : c.x) {
+                const uint64_t xv = x ^ salt;
+                acc ^= fastmod::fastmod_u64(xv * a, M, p);
+            }
         }
     }
-
     auto end = hrc::now();
+    volatile uint64_t sink = acc;
     (void)sink;
 
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-    return {"fastmod_u64", ns, ops, static_cast<double>(ns) / static_cast<double>(ops)};
+    double ns =
+        static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count());
+    double ops = static_cast<double>(reps) * static_cast<double>(combos.size()) *
+        static_cast<double>(combos.front().x.size());
+    return ns / ops;
 }
 
-bool verify(const std::vector<Params>& params) {
-    std::vector<__uint128_t> M;
-    M.reserve(params.size());
-    for (const auto& hp : params) {
-        M.push_back(fastmod::computeM_u64(hp.p));
-    }
+double median(std::vector<double> v) {
+    std::sort(v.begin(), v.end());
+    const size_t n = v.size();
+    if (n == 0)
+        return 0.0;
+    return (n % 2) ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
+}
 
+// Confirm fastmod == native % over the buffer plus boundary x values.
+bool verify(const std::vector<Combo>& combos) {
     size_t checked = 0;
-    for (size_t i = 0; i < params.size(); ++i) {
-        uint64_t a = params[i].a;
-        uint64_t p_val = params[i].p;
-        __uint128_t m_val = M[i];
-        for (uint64_t x : params[i].x) {
-            uint64_t expected = (x * a) % p_val;
-            uint64_t got = fastmod::fastmod_u64(x * a, m_val, p_val);
+    for (const auto& c : combos) {
+        std::vector<uint64_t> probes = {0, 1, 2, c.p - 1, c.p + 1, 0xFFFFFFFFull};
+        probes.insert(probes.end(), c.x.begin(), c.x.end());
+        for (uint64_t xraw : probes) {
+            const uint64_t x = static_cast<uint32_t>(xraw);  // mixed keys live in the 32-bit domain
+            const uint64_t prod = x * c.a;
+            const uint64_t expected = prod % c.p;
+            const uint64_t got = fastmod::fastmod_u64(prod, c.M, c.p);
             if (expected != got) {
-                std::cerr << "MISMATCH: a=" << a << " x=" << x << " p=" << p_val << " native=" << expected
+                std::cerr << "MISMATCH: a=" << c.a << " x=" << x << " p=" << c.p << " native=" << expected
                           << " fastmod=" << got << std::endl;
                 return false;
             }
             ++checked;
         }
     }
-
     std::cout << "Correctness: " << checked << " ops, all equal." << std::endl;
     return true;
 }
 
 struct Config {
-    size_t n = 10'000'000;
-    size_t batch = 10;
+    size_t n = 10'000'000;  // sizes the prime (matches the real regime), NOT the buffer
+    size_t keys = 4096;  // per-combo key buffer; keys*batch stays cache-resident
+    size_t batch = 16;  // number of distinct primes rotated through
+    size_t ops = 200'000'000;  // approximate total operations timed per trial
+    size_t trials = 7;  // repetitions; the median is reported
     uint64_t seed = 42;
 };
 
 int run(const Config& cfg) {
     std::cout << "=== fastmod_u64 micro-bench ===\n"
-              << "n=" << cfg.n << " batch=" << cfg.batch << " seed=" << cfg.seed << std::endl;
+              << "n(prime)=" << cfg.n << " keys=" << cfg.keys << " batch=" << cfg.batch << " ops~" << cfg.ops
+              << " trials=" << cfg.trials << " seed=" << cfg.seed << std::endl;
 
-    // Sanity: correctness on small batch first.
-    {
-        auto p = gen_params(1000, 2, cfg.seed);
-        if (!verify(p)) {
-            std::cerr << "FAIL" << std::endl;
-            return 1;
-        }
+    auto combos = gen_combos(cfg.n, cfg.keys, cfg.batch, cfg.seed);
+    const size_t ws_kb = (cfg.keys * cfg.batch * sizeof(uint64_t)) / 1024;
+    std::cout << "primes [" << combos.front().p << ", " << combos.back().p << "]  working set " << ws_kb
+              << " KB total" << std::endl;
+
+    if (!verify(combos)) {
+        std::cerr << "FAIL" << std::endl;
+        return 1;
     }
 
-    auto params = gen_params(cfg.n, cfg.batch, cfg.seed);
-    std::cout << "primes [" << params.front().p << ", " << params.back().p << "]" << std::endl;
+    const size_t reps = reps_for(cfg.ops, cfg.batch, cfg.keys);
 
-    auto native = bench_native(params);
-    std::cout << native.label << ": " << native.total_ns << " ns / " << native.iterations << " = "
-              << native.ns_per_op << " ns/op" << std::endl;
+    // Warm-up (untimed): spin up frequency, prime caches.
+    bench_native(combos, 1);
+    bench_fastmod(combos, 1);
 
-    auto fm = bench_fastmod(params);
-    std::cout << fm.label << ": " << fm.total_ns << " ns / " << fm.iterations << " = " << fm.ns_per_op
-              << " ns/op" << std::endl;
+    std::vector<double> nat, fm;
+    nat.reserve(cfg.trials);
+    fm.reserve(cfg.trials);
+    for (size_t t = 0; t < cfg.trials; ++t) {
+        nat.push_back(bench_native(combos, reps));  // alternate the two so drift hits both equally
+        fm.push_back(bench_fastmod(combos, reps));
+    }
 
-    double ratio = fm.ns_per_op / native.ns_per_op;
+    const double nat_med = median(nat);
+    const double fm_med = median(fm);
+    std::cout << "native %    median: " << nat_med << " ns/op  (min "
+              << *std::min_element(nat.begin(), nat.end()) << ", max "
+              << *std::max_element(nat.begin(), nat.end()) << ")" << std::endl;
+    std::cout << "fastmod_u64 median: " << fm_med << " ns/op  (min "
+              << *std::min_element(fm.begin(), fm.end()) << ", max "
+              << *std::max_element(fm.begin(), fm.end()) << ")" << std::endl;
+
+    const double ratio = fm_med / nat_med;
     if (ratio < 1.0) {
         std::cout << "fastmod wins: " << (1.0 / ratio) << "x faster" << std::endl;
     } else {
         std::cout << "native wins: " << ratio << "x faster" << std::endl;
     }
-
     return 0;
 }
 
@@ -193,9 +228,12 @@ int run(const Config& cfg) {
 int main(int argc, char** argv) {
     Config cfg;
 
-    CLI::App app{"fastmod_u64 vs native % micro-bench"};
-    app.add_option("-n", cfg.n, "Logical N (determines prime sizes)")->capture_default_str();
-    app.add_option("--batch", cfg.batch, "Number of (p,a,x[]) combos")->capture_default_str();
+    CLI::App app{"fastmod_u64 vs native % micro-bench (compute-isolated)"};
+    app.add_option("-n", cfg.n, "Logical N (determines prime magnitude)")->capture_default_str();
+    app.add_option("--keys", cfg.keys, "Keys per combo (buffer stays cache-resident)")->capture_default_str();
+    app.add_option("--batch", cfg.batch, "Number of distinct primes")->capture_default_str();
+    app.add_option("--ops", cfg.ops, "Approx total ops timed per trial")->capture_default_str();
+    app.add_option("--trials", cfg.trials, "Repetitions (median reported)")->capture_default_str();
     app.add_option("--seed", cfg.seed, "RNG seed")->capture_default_str();
 
     CLI11_PARSE(app, argc, argv);

--- a/src/bench/bench_fastmod_micro.cpp
+++ b/src/bench/bench_fastmod_micro.cpp
@@ -1,17 +1,6 @@
-// Micro-benchmark: fastmod_u64 vs native % in the MPHF hash regime.
-// Measures (a * x) % p with a < p < 2^32, x < 2^32, so a*x < 2^64.
-//
-// Design (why the bench is shaped this way):
-//  - p is runtime-variable per combo, so native % compiles to a real hardware divide.
-//    A compile-time-constant divisor would let the compiler emit its own magic-multiply
-//    (i.e. fastmod), making the comparison meaningless.
-//  - The key buffer is small and cache-resident: this bench isolates COMPUTE cost only.
-//    Out-of-cache / memory-bandwidth effects belong to the end-to-end --glgh benchmark,
-//    not here. `n` sizes the prime (matching the real regime), it does NOT size the buffer.
-//  - Anti-DCE via a single volatile store AFTER each timed loop, not one per iteration
-//    (a per-iteration volatile RMW adds fixed overhead that compresses the ratio).
-//  - Each measurement is warmed up, repeated `trials` times, and reported as the median;
-//    single-pass timings on this workload swing wildly (turbo ramp, scheduling).
+// micro-bench: fastmod_u64 vs native % in the real MPHF hash regime
+// p is runtime-variable per combo so native % emits a real divq (not a compiler
+// magic-multiply). Buffer is cache-resident: this should measures compute instead of memory. The median of several trials is reported.
 
 #include <hashing/mixers.hpp>
 #include <hashing/mphf_utils.hpp>
@@ -33,17 +22,14 @@ namespace {
 
 using hrc = std::chrono::high_resolution_clock;
 
-// One (p, a, key-buffer) combo. M is the fastmod reciprocal, precomputed once.
 struct Combo {
     uint64_t p;
     uint64_t a;
-    __uint128_t M;
-    std::vector<uint64_t> x;  // cache-resident buffer of premixed keys
+    __uint128_t M;  // fastmod reciprocal
+    std::vector<uint64_t> x;
 };
 
-// Prime magnitude for a logical N, mirroring MPHF::compute_target_segment:
-// m ~ 1.25*n slots split across 3 segments, so each prime ~ 0.42*n.
-uint64_t prime_base_for_n(size_t n) {
+uint64_t prime_base_for_n(size_t n) {  // mirrors MPHF::compute_target_segment
     uint64_t target_m = static_cast<uint64_t>(std::ceil(1.25 * static_cast<double>(n)));
     uint64_t target = std::max<uint64_t>(3, (target_m + 2) / 3);
     return cltj::hashing::next_prime(target);
@@ -75,7 +61,6 @@ std::vector<Combo> gen_combos(size_t n_for_prime, size_t keys, size_t batch, uin
     return combos;
 }
 
-// How many passes over the buffers to reach ~target_ops operations.
 size_t reps_for(size_t target_ops, size_t batch, size_t keys) {
     size_t per_pass = batch * keys;
     if (per_pass == 0)
@@ -83,8 +68,6 @@ size_t reps_for(size_t target_ops, size_t batch, size_t keys) {
     return std::max<size_t>((target_ops + per_pass - 1) / per_pass, 1);
 }
 
-// Per-rep salt (xor with the pass index) keeps xv < 2^32 while making each pass distinct,
-// so the compiler cannot hoist/CSE the inner work across the reps loop.
 double bench_native(const std::vector<Combo>& combos, size_t reps) {
     uint64_t acc = 0;
     auto start = hrc::now();
@@ -100,7 +83,7 @@ double bench_native(const std::vector<Combo>& combos, size_t reps) {
         }
     }
     auto end = hrc::now();
-    volatile uint64_t sink = acc;  // single anti-DCE store
+    volatile uint64_t sink = acc;
     (void)sink;
 
     double ns =
@@ -144,26 +127,19 @@ double median(std::vector<double> v) {
     return (n % 2) ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
 }
 
-// Confirm fastmod == native % over the buffer plus boundary x values.
 bool verify(const std::vector<Combo>& combos) {
-    size_t checked = 0;
     for (const auto& c : combos) {
         std::vector<uint64_t> probes = {0, 1, 2, c.p - 1, c.p + 1, 0xFFFFFFFFull};
         probes.insert(probes.end(), c.x.begin(), c.x.end());
         for (uint64_t xraw : probes) {
-            const uint64_t x = static_cast<uint32_t>(xraw);  // mixed keys live in the 32-bit domain
+            const uint64_t x = static_cast<uint32_t>(xraw);
             const uint64_t prod = x * c.a;
-            const uint64_t expected = prod % c.p;
-            const uint64_t got = fastmod::fastmod_u64(prod, c.M, c.p);
-            if (expected != got) {
-                std::cerr << "MISMATCH: a=" << c.a << " x=" << x << " p=" << c.p << " native=" << expected
-                          << " fastmod=" << got << std::endl;
+            if (fastmod::fastmod_u64(prod, c.M, c.p) != prod % c.p) {
+                std::cerr << "MISMATCH: a=" << c.a << " x=" << x << " p=" << c.p << std::endl;
                 return false;
             }
-            ++checked;
         }
     }
-    std::cout << "Correctness: " << checked << " ops, all equal." << std::endl;
     return true;
 }
 
@@ -193,33 +169,29 @@ int run(const Config& cfg) {
 
     const size_t reps = reps_for(cfg.ops, cfg.batch, cfg.keys);
 
-    // Warm-up (untimed): spin up frequency, prime caches.
-    bench_native(combos, 1);
+    bench_native(combos, 1);  // warm-up
     bench_fastmod(combos, 1);
 
     std::vector<double> nat, fm;
     nat.reserve(cfg.trials);
     fm.reserve(cfg.trials);
     for (size_t t = 0; t < cfg.trials; ++t) {
-        nat.push_back(bench_native(combos, reps));  // alternate the two so drift hits both equally
+        nat.push_back(bench_native(combos, reps));
         fm.push_back(bench_fastmod(combos, reps));
     }
 
     const double nat_med = median(nat);
     const double fm_med = median(fm);
-    std::cout << "native %    median: " << nat_med << " ns/op  (min "
-              << *std::min_element(nat.begin(), nat.end()) << ", max "
-              << *std::max_element(nat.begin(), nat.end()) << ")" << std::endl;
-    std::cout << "fastmod_u64 median: " << fm_med << " ns/op  (min "
-              << *std::min_element(fm.begin(), fm.end()) << ", max "
-              << *std::max_element(fm.begin(), fm.end()) << ")" << std::endl;
+    std::cout << "native %    " << nat_med << " ns/op [" << *std::min_element(nat.begin(), nat.end()) << ", "
+              << *std::max_element(nat.begin(), nat.end()) << "]" << std::endl;
+    std::cout << "fastmod_u64 " << fm_med << " ns/op [" << *std::min_element(fm.begin(), fm.end()) << ", "
+              << *std::max_element(fm.begin(), fm.end()) << "]" << std::endl;
 
     const double ratio = fm_med / nat_med;
-    if (ratio < 1.0) {
-        std::cout << "fastmod wins: " << (1.0 / ratio) << "x faster" << std::endl;
-    } else {
-        std::cout << "native wins: " << ratio << "x faster" << std::endl;
-    }
+    if (ratio < 1.0)
+        std::cout << "fastmod " << (1.0 / ratio) << "x faster" << std::endl;
+    else
+        std::cout << "native " << ratio << "x faster" << std::endl;
     return 0;
 }
 

--- a/src/test/hashing/test_modpolicy.cpp
+++ b/src/test/hashing/test_modpolicy.cpp
@@ -3,7 +3,6 @@
 #include <util/logger.hpp>
 
 #include <algorithm>
-#include <cassert>
 #include <cmath>
 #include <random>
 #include <sstream>
@@ -55,7 +54,7 @@ std::vector<uint32_t> make_non_keys(const std::vector<uint32_t>& keys, size_t n,
     return non_keys;
 }
 
-void test_fastmod_equivalence() {
+bool test_fastmod_equivalence() {
     LOG_INFO("Testing fastmod_u64 vs native % ...");
     size_t checked = 0;
     for (uint64_t n : {1000UL, 100000UL, 10000000UL}) {
@@ -72,35 +71,37 @@ void test_fastmod_equivalence() {
                 xs.push_back(premix32(distX(rng)));
             }
             for (uint64_t x : xs) {
-                assert(fastmod::fastmod_u64(x * a, M, p) == (x * a) % p);
+                if (fastmod::fastmod_u64(x * a, M, p) != (x * a) % p) return false;
                 ++checked;
             }
         }
     }
     LOG_INFO("fastmod_u64 == native % on " << checked << " cases");
+    return true;
 }
 
-void test_mphf_equivalence(const std::vector<uint32_t>& keys, const std::vector<uint32_t>& non_keys) {
+bool test_mphf_equivalence(const std::vector<uint32_t>& keys, const std::vector<uint32_t>& non_keys) {
     MPHFNative mphf_native;
     MPHFFast mphf_fast;
-    assert(mphf_native.build(keys));
-    assert(mphf_fast.build(keys));
+    if (!mphf_native.build(keys)) return false;
+    if (!mphf_fast.build(keys)) return false;
 
     for (uint32_t k : keys) {
-        assert(mphf_native.query(k) == mphf_fast.query(k));
+        if (mphf_native.query(k) != mphf_fast.query(k)) return false;
         auto ln = mphf_native.locate(k);
         auto lf = mphf_fast.locate(k);
-        assert(ln.first && lf.first);
-        assert(ln.second == lf.second);
+        if (!(ln.first && lf.first)) return false;
+        if (ln.second != lf.second) return false;
     }
     for (uint32_t nk : non_keys) {
-        assert(mphf_native.locate(nk) == mphf_fast.locate(nk));
+        if (mphf_native.locate(nk) != mphf_fast.locate(nk)) return false;
     }
+    return true;
 }
 
-void test_round_trip(const std::vector<uint32_t>& keys) {
+bool test_round_trip(const std::vector<uint32_t>& keys) {
     MPHFFast mphf;
-    assert(mphf.build(keys));
+    if (!mphf.build(keys)) return false;
 
     std::stringstream ss;
     mphf.serialize(ss);
@@ -108,21 +109,22 @@ void test_round_trip(const std::vector<uint32_t>& keys) {
     loaded.load(ss);
 
     for (uint32_t k : keys) {
-        assert(mphf.query(k) == loaded.query(k));
+        if (mphf.query(k) != loaded.query(k)) return false;
         auto lf = loaded.locate(k);
-        assert(lf.first && lf.second == mphf.locate(k).second);
+        if (!(lf.first && lf.second == mphf.locate(k).second)) return false;
     }
+    return true;
 }
 
 }  // namespace
 
 int main() {
-    test_fastmod_equivalence();
+    if (!test_fastmod_equivalence()) return 1;
 
     auto keys = make_random_keys(20000, 12345);
     auto non_keys = make_non_keys(keys, 20000, 999);
     LOG_INFO("Testing MPHF equivalence (random keys) ...");
-    test_mphf_equivalence(keys, non_keys);
+    if (!test_mphf_equivalence(keys, non_keys)) return 1;
 
     std::vector<uint32_t> consecutive(20000);
     for (uint32_t i = 0; i < consecutive.size(); ++i) {
@@ -130,11 +132,11 @@ int main() {
     }
     auto cons_non_keys = make_non_keys(consecutive, 20000, 555);
     LOG_INFO("Testing MPHF equivalence (consecutive keys) ...");
-    test_mphf_equivalence(consecutive, cons_non_keys);
+    if (!test_mphf_equivalence(consecutive, cons_non_keys)) return 1;
 
     LOG_INFO("Testing FastMod serialize/load round-trip ...");
-    test_round_trip(keys);
-    test_round_trip(consecutive);
+    if (!test_round_trip(keys)) return 1;
+    if (!test_round_trip(consecutive)) return 1;
 
     LOG_INFO("All mod policy tests passed successfully!");
     return 0;

--- a/src/test/hashing/test_modpolicy.cpp
+++ b/src/test/hashing/test_modpolicy.cpp
@@ -1,0 +1,141 @@
+#include <hashing/mphf_bdz.hpp>
+#include <hashing/storage/glgh.hpp>
+#include <util/logger.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <random>
+#include <sstream>
+#include <unordered_set>
+#include <vector>
+
+using cltj::hashing::GlGhStorage;
+using cltj::hashing::MPHF;
+using cltj::hashing::next_prime;
+using cltj::hashing::premix32;
+using cltj::hashing::policies::FastMod;
+using cltj::hashing::policies::NativeMod;
+using cltj::hashing::policies::QuotientKey;
+
+namespace {
+
+using MPHFNative = MPHF<GlGhStorage, QuotientKey, NativeMod>;
+using MPHFFast = MPHF<GlGhStorage, QuotientKey, FastMod>;
+
+uint64_t regime_prime(uint64_t n, int which) {
+    uint64_t target = std::max<uint64_t>(3, ((uint64_t)std::ceil(1.25 * (double)n) + 2) / 3);
+    uint64_t p = next_prime(target);
+    for (int i = 0; i < which; ++i) {
+        p = next_prime(p + 1);
+    }
+    return p;
+}
+
+std::vector<uint32_t> make_random_keys(size_t n, uint32_t seed) {
+    std::unordered_set<uint32_t> key_set;
+    key_set.reserve(n);
+    std::mt19937 rng(seed);
+    while (key_set.size() < n) {
+        key_set.insert(rng());
+    }
+    return std::vector<uint32_t>(key_set.begin(), key_set.end());
+}
+
+std::vector<uint32_t> make_non_keys(const std::vector<uint32_t>& keys, size_t n, uint32_t seed) {
+    std::unordered_set<uint32_t> key_set(keys.begin(), keys.end());
+    std::vector<uint32_t> non_keys;
+    std::mt19937 rng(seed);
+    while (non_keys.size() < n) {
+        uint32_t candidate = rng();
+        if (!key_set.count(candidate)) {
+            non_keys.push_back(candidate);
+        }
+    }
+    return non_keys;
+}
+
+void test_fastmod_equivalence() {
+    LOG_INFO("Testing fastmod_u64 vs native % ...");
+    size_t checked = 0;
+    for (uint64_t n : {1000UL, 100000UL, 10000000UL}) {
+        for (int k = 0; k < 3; ++k) {
+            uint64_t p = regime_prime(n, k);
+            __uint128_t M = fastmod::computeM_u64(p);
+            std::mt19937_64 rng(n * 10 + k);
+            std::uniform_int_distribution<uint64_t> distA(1, p - 1);
+            uint64_t a = distA(rng);
+
+            std::vector<uint64_t> xs = {0, 1, 2, p - 1, p, p + 1, 0xFFFFFFFFull};
+            std::uniform_int_distribution<uint32_t> distX;
+            for (int i = 0; i < 10000; ++i) {
+                xs.push_back(premix32(distX(rng)));
+            }
+            for (uint64_t x : xs) {
+                assert(fastmod::fastmod_u64(x * a, M, p) == (x * a) % p);
+                ++checked;
+            }
+        }
+    }
+    LOG_INFO("fastmod_u64 == native % on " << checked << " cases");
+}
+
+void test_mphf_equivalence(const std::vector<uint32_t>& keys, const std::vector<uint32_t>& non_keys) {
+    MPHFNative mphf_native;
+    MPHFFast mphf_fast;
+    assert(mphf_native.build(keys));
+    assert(mphf_fast.build(keys));
+
+    for (uint32_t k : keys) {
+        assert(mphf_native.query(k) == mphf_fast.query(k));
+        auto ln = mphf_native.locate(k);
+        auto lf = mphf_fast.locate(k);
+        assert(ln.first && lf.first);
+        assert(ln.second == lf.second);
+    }
+    for (uint32_t nk : non_keys) {
+        assert(mphf_native.locate(nk) == mphf_fast.locate(nk));
+    }
+}
+
+void test_round_trip(const std::vector<uint32_t>& keys) {
+    MPHFFast mphf;
+    assert(mphf.build(keys));
+
+    std::stringstream ss;
+    mphf.serialize(ss);
+    MPHFFast loaded;
+    loaded.load(ss);
+
+    for (uint32_t k : keys) {
+        assert(mphf.query(k) == loaded.query(k));
+        auto lf = loaded.locate(k);
+        assert(lf.first && lf.second == mphf.locate(k).second);
+    }
+}
+
+}  // namespace
+
+int main() {
+    test_fastmod_equivalence();
+
+    auto keys = make_random_keys(20000, 12345);
+    auto non_keys = make_non_keys(keys, 20000, 999);
+    LOG_INFO("Testing MPHF equivalence (random keys) ...");
+    test_mphf_equivalence(keys, non_keys);
+
+    std::vector<uint32_t> consecutive(20000);
+    for (uint32_t i = 0; i < consecutive.size(); ++i) {
+        consecutive[i] = 1000000 + i;
+    }
+    auto cons_non_keys = make_non_keys(consecutive, 20000, 555);
+    LOG_INFO("Testing MPHF equivalence (consecutive keys) ...");
+    test_mphf_equivalence(consecutive, cons_non_keys);
+
+    LOG_INFO("Testing FastMod serialize/load round-trip ...");
+    test_round_trip(keys);
+    test_round_trip(consecutive);
+
+    LOG_INFO("All mod policy tests passed successfully!");
+    return 0;
+}

--- a/src/test/hashing/test_mphf_size_breakdown.cpp
+++ b/src/test/hashing/test_mphf_size_breakdown.cpp
@@ -1,6 +1,7 @@
 #include <hashing/mphf_bdz.hpp>
 #include <hashing/storage/packed_trit.hpp>
 #include <hashing/storage/glgh.hpp>
+#include <hashing/storage/packed_glgh.hpp>
 #include <hashing/key_policies.hpp>
 #include <iomanip>
 #include <sstream>
@@ -15,6 +16,7 @@ using cltj::hashing::BaselineStorage;
 using cltj::hashing::CompressedBitvector;
 using cltj::hashing::GlGhStorage;
 using cltj::hashing::MPHF;
+using cltj::hashing::PackedGlGhStorage;
 using cltj::hashing::PackedTritStorage;
 using cltj::hashing::policies::NoKey;
 using cltj::hashing::policies::QuotientKey;
@@ -104,7 +106,15 @@ int main() {
             "[GlGhStorage (Gl/Gh on-the-fly B)]",
             keys,
             "Gl + Gh bitvectors",
-            "B stored explicitly",
+            "B implicit (not stored)",
+            "Rank metadata (on-the-fly B)"
+        );
+
+        analyze_strategy<PackedGlGhStorage, NoKey>(
+            "[PackedGlGhStorage (single int_vector<2>, on-the-fly B)]",
+            keys,
+            "G array (2-bit lanes)",
+            "B implicit (not stored)",
             "Rank metadata (on-the-fly B)"
         );
 
@@ -112,7 +122,7 @@ int main() {
             "[GlGhStorage + QuotientKey payload]",
             keys,
             "Gl + Gh bitvectors",
-            "B stored explicitly",
+            "B implicit (not stored)",
             "Rank metadata (on-the-fly B)"
         );
 

--- a/src/test/hashing/test_packed_glgh.cpp
+++ b/src/test/hashing/test_packed_glgh.cpp
@@ -1,0 +1,156 @@
+#include <hashing/storage/glgh.hpp>
+#include <hashing/storage/packed_glgh.hpp>
+
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <vector>
+
+using cltj::hashing::GlGhStorage;
+using cltj::hashing::PackedGlGhStorage;
+
+std::vector<uint32_t> random_values(size_t m, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::uniform_int_distribution<uint32_t> dist(0, 3);
+
+    std::vector<uint32_t> values(m);
+    for (size_t i = 0; i < m; ++i) {
+        values[i] = dist(rng);
+    }
+    return values;
+}
+
+std::vector<uint32_t> filled_values(size_t m, uint32_t value) {
+    return std::vector<uint32_t>(m, value);
+}
+
+void fill_storage(GlGhStorage& glgh, PackedGlGhStorage& packed, const std::vector<uint32_t>& values) {
+    const uint32_t m = static_cast<uint32_t>(values.size());
+    glgh.initialize(m);
+    packed.initialize(m);
+
+    for (uint32_t v = 0; v < m; ++v) {
+        glgh.g_set(v, values[v]);
+        packed.g_set(v, values[v]);
+    }
+}
+
+bool check_against_glgh(const std::vector<uint32_t>& values) {
+    GlGhStorage glgh;
+    PackedGlGhStorage packed;
+    fill_storage(glgh, packed, values);
+
+    const uint32_t m = static_cast<uint32_t>(values.size());
+    if (glgh.m() != packed.m())
+        return false;
+
+    for (uint32_t v = 0; v < m; ++v) {
+        if (packed.g_get(v) != glgh.g_get(v))
+            return false;
+        if (packed.is_vertex_occupied(v) != glgh.is_vertex_occupied(v))
+            return false;
+    }
+
+    if (packed.g_get(m + 10) != 3)
+        return false;
+    if (packed.is_vertex_occupied(m + 10))
+        return false;
+
+    glgh.build_rank();
+    packed.build_rank();
+
+    for (uint32_t v = 0; v <= m; ++v) {
+        if (packed.rank(v) != glgh.rank(v))
+            return false;
+    }
+    if (packed.rank(m + 10) != glgh.rank(m))
+        return false;
+
+    auto breakdown = packed.get_size_breakdown();
+    if (breakdown.used_pos_bytes != 0)
+        return false;
+    if (breakdown.g_bytes == 0 && m > 0)
+        return false;
+    if (breakdown.rank_bytes == 0 && m > 0)
+        return false;
+
+    return true;
+}
+
+bool check_round_trip(const std::vector<uint32_t>& values) {
+    PackedGlGhStorage packed;
+    packed.initialize(static_cast<uint32_t>(values.size()));
+    for (uint32_t v = 0; v < values.size(); ++v) {
+        packed.g_set(v, values[v]);
+    }
+    packed.build_rank();
+
+    std::stringstream ss;
+    packed.serialize(ss, nullptr, "packed");
+
+    PackedGlGhStorage loaded;
+    loaded.load(ss);
+
+    if (loaded.m() != packed.m())
+        return false;
+
+    for (uint32_t v = 0; v < packed.m(); ++v) {
+        if (loaded.g_get(v) != packed.g_get(v))
+            return false;
+        if (loaded.is_vertex_occupied(v) != packed.is_vertex_occupied(v))
+            return false;
+    }
+
+    for (uint32_t v = 0; v <= packed.m(); ++v) {
+        if (loaded.rank(v) != packed.rank(v))
+            return false;
+    }
+
+    return true;
+}
+
+int main() {
+    std::cout << "Testing PackedGlGhStorage ...\n";
+    int failures = 0;
+
+    {
+        bool ok = true;
+        for (size_t m : {511ul, 50000ul, 65536ul, 49999ul}) {
+            if (!check_against_glgh(random_values(m, 42))) {
+                ok = false;
+                break;
+            }
+        }
+        if (!ok)
+            ++failures;
+        std::cout << "  random equivalence vs GlGhStorage: " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    {
+        const size_t m = 10000;
+        bool ok = check_against_glgh(filled_values(m, 0));
+        if (!ok)
+            ++failures;
+        std::cout << "  all occupied: " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    {
+        const size_t m = 10000;
+        bool ok = check_against_glgh(filled_values(m, 3));
+        if (!ok)
+            ++failures;
+        std::cout << "  all unassigned: " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    {
+        bool ok = check_round_trip(random_values(50000, 7));
+        if (!ok)
+            ++failures;
+        std::cout << "  serialize/load round-trip: " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    if (failures == 0) {
+        std::cout << "All PackedGlGhStorage tests passed.\n";
+    }
+    return failures;
+}

--- a/src/test/hashing/test_packed_glgh_mphf.cpp
+++ b/src/test/hashing/test_packed_glgh_mphf.cpp
@@ -1,0 +1,221 @@
+#include <hashing/mphf_bdz.hpp>
+#include <hashing/storage/glgh.hpp>
+#include <hashing/storage/packed_glgh.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <unordered_set>
+#include <vector>
+
+using cltj::hashing::GlGhStorage;
+using cltj::hashing::MPHF;
+using cltj::hashing::PackedGlGhStorage;
+using cltj::hashing::policies::NoKey;
+using cltj::hashing::policies::QuotientKey;
+
+std::vector<uint32_t> consecutive_keys(size_t n) {
+    std::vector<uint32_t> keys(n);
+    for (size_t i = 0; i < n; ++i) {
+        keys[i] = static_cast<uint32_t>(i + 1);
+    }
+    return keys;
+}
+
+std::vector<uint32_t> random_keys(size_t n, uint64_t seed) {
+    std::mt19937_64 rng(seed);
+    std::unordered_set<uint32_t> seen;
+    seen.reserve(n * 2);
+    std::uniform_int_distribution<uint32_t> dist(1, static_cast<uint32_t>(n * 100));
+
+    while (seen.size() < n) {
+        seen.insert(dist(rng));
+    }
+    return std::vector<uint32_t>(seen.begin(), seen.end());
+}
+
+std::vector<uint32_t> non_keys(const std::vector<uint32_t>& keys, size_t count) {
+    std::unordered_set<uint32_t> key_set(keys.begin(), keys.end());
+    std::vector<uint32_t> result;
+    result.reserve(count);
+
+    uint32_t candidate = 1;
+    while (result.size() < count) {
+        if (!key_set.count(candidate)) {
+            result.push_back(candidate);
+        }
+        ++candidate;
+    }
+    return result;
+}
+
+template <typename Mphf>
+bool check_permutation(const Mphf& mphf, const std::vector<uint32_t>& keys) {
+    std::vector<uint8_t> seen(keys.size(), 0);
+    for (uint32_t key : keys) {
+        uint32_t h = mphf.query(key);
+        if (h >= keys.size())
+            return false;
+        if (seen[h])
+            return false;
+        seen[h] = 1;
+    }
+    return std::all_of(seen.begin(), seen.end(), [](uint8_t v) { return v != 0; });
+}
+
+bool check_nokey_equivalence(const std::vector<uint32_t>& keys) {
+    MPHF<GlGhStorage, NoKey> glgh;
+    MPHF<PackedGlGhStorage, NoKey> packed;
+
+    if (!glgh.build(keys))
+        return false;
+    if (!packed.build(keys))
+        return false;
+
+    if (glgh.n() != packed.n())
+        return false;
+    if (glgh.m() != packed.m())
+        return false;
+    if (glgh.retry_count() != packed.retry_count())
+        return false;
+    if (glgh.n_peeled() != packed.n_peeled())
+        return false;
+    if (glgh.n_residual() != packed.n_residual())
+        return false;
+
+    if (!check_permutation(glgh, keys))
+        return false;
+    if (!check_permutation(packed, keys))
+        return false;
+
+    for (uint32_t key : keys) {
+        if (packed.query(key) != glgh.query(key))
+            return false;
+    }
+    return true;
+}
+
+bool check_quotient_equivalence(const std::vector<uint32_t>& keys) {
+    MPHF<GlGhStorage, QuotientKey> glgh;
+    MPHF<PackedGlGhStorage, QuotientKey> packed;
+
+    if (!glgh.build(keys))
+        return false;
+    if (!packed.build(keys))
+        return false;
+
+    if (glgh.n() != packed.n())
+        return false;
+    if (glgh.m() != packed.m())
+        return false;
+    if (glgh.retry_count() != packed.retry_count())
+        return false;
+    if (glgh.n_peeled() != packed.n_peeled())
+        return false;
+    if (glgh.n_residual() != packed.n_residual())
+        return false;
+
+    for (uint32_t key : keys) {
+        auto a = glgh.locate(key);
+        auto b = packed.locate(key);
+        if (!a.first || !b.first)
+            return false;
+        if (a.second != b.second)
+            return false;
+        if (glgh.query(key) != packed.query(key))
+            return false;
+    }
+
+    for (uint32_t key : non_keys(keys, 1000)) {
+        if (glgh.contains(key))
+            return false;
+        if (packed.contains(key))
+            return false;
+    }
+    return true;
+}
+
+bool check_round_trip(const std::vector<uint32_t>& keys) {
+    MPHF<PackedGlGhStorage, QuotientKey> packed;
+    if (!packed.build(keys))
+        return false;
+
+    std::stringstream ss;
+    packed.serialize(ss);
+
+    MPHF<PackedGlGhStorage, QuotientKey> loaded;
+    loaded.load(ss);
+
+    if (loaded.n() != packed.n())
+        return false;
+    if (loaded.m() != packed.m())
+        return false;
+    if (loaded.n_peeled() != packed.n_peeled())
+        return false;
+    if (loaded.n_residual() != packed.n_residual())
+        return false;
+
+    for (uint32_t key : keys) {
+        if (loaded.query(key) != packed.query(key))
+            return false;
+        if (loaded.locate(key) != packed.locate(key))
+            return false;
+    }
+
+    for (uint32_t key : non_keys(keys, 1000)) {
+        if (loaded.contains(key))
+            return false;
+    }
+    return true;
+}
+
+int main() {
+    std::cout << "Testing PackedGlGhStorage inside MPHF ...\n";
+    int failures = 0;
+
+    std::vector<std::vector<uint32_t>> datasets;
+    datasets.push_back(consecutive_keys(1000));
+    datasets.push_back(consecutive_keys(10000));
+    datasets.push_back(random_keys(1000, 42));
+    datasets.push_back(random_keys(10000, 43));
+
+    {
+        bool ok = true;
+        for (const auto& keys : datasets) {
+            if (!check_nokey_equivalence(keys)) {
+                ok = false;
+                break;
+            }
+        }
+        if (!ok)
+            ++failures;
+        std::cout << "  NoKey equivalence vs GlGhStorage: " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    {
+        bool ok = true;
+        for (const auto& keys : datasets) {
+            if (!check_quotient_equivalence(keys)) {
+                ok = false;
+                break;
+            }
+        }
+        if (!ok)
+            ++failures;
+        std::cout << "  QuotientKey equivalence vs GlGhStorage: " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    {
+        bool ok = check_round_trip(random_keys(10000, 7));
+        if (!ok)
+            ++failures;
+        std::cout << "  Packed MPHF serialize/load round-trip: " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    if (failures == 0) {
+        std::cout << "All PackedGlGhStorage MPHF tests passed.\n";
+    }
+    return failures;
+}

--- a/src/test/hashing/test_rank_support_packed_glgh.cpp
+++ b/src/test/hashing/test_rank_support_packed_glgh.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <iostream>
 #include <random>
+#include <sstream>
 
 /**
  * @brief Build a pair (Gl, Gh, G) encoding the same random G values.
@@ -32,26 +33,33 @@ int main() {
     std::cout << "Testing rank_support_packed_glgh vs rank_support_glgh ...\n";
     int failures = 0;
 
-    // Random case.
+    // Random case, several sizes: a plain size, a superblock boundary (m%256==0),
+    // an odd size, and a size below one superblock.
     {
-        const size_t m = 50000;
-        DualVectors dv(m, 42);
+        bool ok = true;
+        for (size_t m : {50000ul, 65536ul, 49999ul, 511ul}) {
+            DualVectors dv(m, 42);
 
-        cltj::hashing::rank_support_glgh<> rank_glgh(&dv.Gl, &dv.Gh);
-        cltj::hashing::rank_support_packed_glgh rank_packed(&dv.G);
+            cltj::hashing::rank_support_glgh<> rank_glgh(&dv.Gl, &dv.Gh);
+            cltj::hashing::rank_support_packed_glgh rank_packed(&dv.G);
 
-        for (size_t v = 0; v <= m; ++v) {
-            if (rank_packed.rank(v) != rank_glgh.rank(v)) {
-                ++failures;
-                break;
+            for (size_t v = 0; v <= m; ++v) {
+                if (rank_packed.rank(v) != rank_glgh.rank(v)) {
+                    ok = false;
+                    break;
+                }
             }
+            if (!ok)
+                break;
         }
-
-        std::cout << "  random (m=" << m << "): " << (failures ? "FAIL" : "OK") << "\n";
+        if (!ok)
+            ++failures;
+        std::cout << "  random (multiple sizes): " << (ok ? "OK" : "FAIL") << "\n";
     }
 
-    // Edge: all occupied (no 3's, like a full MPHF).
+    // Edge: all occupied (no 3's, like a full MPHF). Here rank(v) must equal v.
     {
+        bool ok = true;
         const size_t m = 10000;
         sdsl::bit_vector Gl(m, 0);
         sdsl::bit_vector Gh(m, 0);
@@ -61,17 +69,20 @@ int main() {
         cltj::hashing::rank_support_packed_glgh rank_packed(&G);
 
         for (size_t v = 0; v <= m; ++v) {
-            if (rank_packed.rank(v) != rank_glgh.rank(v)) {
-                ++failures;
+            if (rank_packed.rank(v) != rank_glgh.rank(v) || rank_packed.rank(v) != v) {
+                ok = false;
                 break;
             }
         }
 
-        std::cout << "  all occupied (m=" << m << "): " << (failures ? "FAIL" : "OK") << "\n";
+        if (!ok)
+            ++failures;
+        std::cout << "  all occupied (m=" << m << "): " << (ok ? "OK" : "FAIL") << "\n";
     }
 
-    // Edge: all unassigned (all 3's).
+    // Edge: all unassigned (all 3's). Here rank(v) must be 0.
     {
+        bool ok = true;
         const size_t m = 10000;
         sdsl::bit_vector Gl(m, 1);
         sdsl::bit_vector Gh(m, 1);
@@ -81,17 +92,39 @@ int main() {
         cltj::hashing::rank_support_packed_glgh rank_packed(&G);
 
         for (size_t v = 0; v <= m; ++v) {
-            if (rank_packed.rank(v) != rank_glgh.rank(v)) {
-                ++failures;
-                break;
-            }
-            if (rank_packed.rank(v) != 0) {
-                ++failures;
+            if (rank_packed.rank(v) != rank_glgh.rank(v) || rank_packed.rank(v) != 0) {
+                ok = false;
                 break;
             }
         }
 
-        std::cout << "  all unassigned (m=" << m << "): " << (failures ? "FAIL" : "OK") << "\n";
+        if (!ok)
+            ++failures;
+        std::cout << "  all unassigned (m=" << m << "): " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
+    // Serialize/load round-trip: a loaded rank must answer like the original.
+    {
+        bool ok = true;
+        const size_t m = 50000;
+        DualVectors dv(m, 7);
+        cltj::hashing::rank_support_packed_glgh rank_packed(&dv.G);
+
+        std::stringstream ss;
+        rank_packed.serialize(ss);
+        cltj::hashing::rank_support_packed_glgh<> loaded;
+        loaded.load(ss, &dv.G);
+
+        for (size_t v = 0; v <= m; ++v) {
+            if (loaded.rank(v) != rank_packed.rank(v)) {
+                ok = false;
+                break;
+            }
+        }
+
+        if (!ok)
+            ++failures;
+        std::cout << "  serialize/load round-trip (m=" << m << "): " << (ok ? "OK" : "FAIL") << "\n";
     }
 
     if (failures == 0)

--- a/src/test/hashing/test_rank_support_packed_glgh.cpp
+++ b/src/test/hashing/test_rank_support_packed_glgh.cpp
@@ -1,0 +1,100 @@
+#include <hashing/storage/rank_support_glgh.hpp>
+#include <hashing/storage/rank_support_packed_glgh.hpp>
+
+#include <cassert>
+#include <iostream>
+#include <random>
+
+/**
+ * @brief Build a pair (Gl, Gh, G) encoding the same random G values.
+ *
+ * G[v] in {0,1,2,3}. Each vertex: Gl[v] = G[v] & 1, Gh[v] = (G[v] >> 1) & 1.
+ * The int_vector<2> stores the same values packed as 2 contiguous bits.
+ */
+struct DualVectors {
+    sdsl::bit_vector Gl;
+    sdsl::bit_vector Gh;
+    sdsl::int_vector<2> G;
+
+    DualVectors(size_t m, uint64_t seed) : Gl(m), Gh(m), G(m) {
+        std::mt19937_64 rng(seed);
+        std::uniform_int_distribution<uint32_t> dist(0, 3);
+        for (size_t v = 0; v < m; ++v) {
+            uint32_t val = dist(rng);
+            Gl[v] = val & 1;
+            Gh[v] = (val >> 1) & 1;
+            G[v] = val;
+        }
+    }
+};
+
+int main() {
+    std::cout << "Testing rank_support_packed_glgh vs rank_support_glgh ...\n";
+    int failures = 0;
+
+    // Random case.
+    {
+        const size_t m = 50000;
+        DualVectors dv(m, 42);
+
+        cltj::hashing::rank_support_glgh<> rank_glgh(&dv.Gl, &dv.Gh);
+        cltj::hashing::rank_support_packed_glgh rank_packed(&dv.G);
+
+        for (size_t v = 0; v <= m; ++v) {
+            if (rank_packed.rank(v) != rank_glgh.rank(v)) {
+                ++failures;
+                break;
+            }
+        }
+
+        std::cout << "  random (m=" << m << "): " << (failures ? "FAIL" : "OK") << "\n";
+    }
+
+    // Edge: all occupied (no 3's, like a full MPHF).
+    {
+        const size_t m = 10000;
+        sdsl::bit_vector Gl(m, 0);
+        sdsl::bit_vector Gh(m, 0);
+        sdsl::int_vector<2> G(m, 0);
+
+        cltj::hashing::rank_support_glgh<> rank_glgh(&Gl, &Gh);
+        cltj::hashing::rank_support_packed_glgh rank_packed(&G);
+
+        for (size_t v = 0; v <= m; ++v) {
+            if (rank_packed.rank(v) != rank_glgh.rank(v)) {
+                ++failures;
+                break;
+            }
+        }
+
+        std::cout << "  all occupied (m=" << m << "): " << (failures ? "FAIL" : "OK") << "\n";
+    }
+
+    // Edge: all unassigned (all 3's).
+    {
+        const size_t m = 10000;
+        sdsl::bit_vector Gl(m, 1);
+        sdsl::bit_vector Gh(m, 1);
+        sdsl::int_vector<2> G(m, 3);
+
+        cltj::hashing::rank_support_glgh<> rank_glgh(&Gl, &Gh);
+        cltj::hashing::rank_support_packed_glgh rank_packed(&G);
+
+        for (size_t v = 0; v <= m; ++v) {
+            if (rank_packed.rank(v) != rank_glgh.rank(v)) {
+                ++failures;
+                break;
+            }
+            if (rank_packed.rank(v) != 0) {
+                ++failures;
+                break;
+            }
+        }
+
+        std::cout << "  all unassigned (m=" << m << "): " << (failures ? "FAIL" : "OK") << "\n";
+    }
+
+    if (failures == 0)
+        std::cout << "All rank_support_packed_glgh tests passed.\n";
+    return failures;
+}

--- a/src/test/hashing/test_rank_support_packed_glgh.cpp
+++ b/src/test/hashing/test_rank_support_packed_glgh.cpp
@@ -103,6 +103,28 @@ int main() {
         std::cout << "  all unassigned (m=" << m << "): " << (ok ? "OK" : "FAIL") << "\n";
     }
 
+    // Boundary near a rank superblock. With 2-bit lanes, m=449 rounds to
+    // 15 physical words, i.e. 8 logical 64-vertex words.
+    {
+        bool ok = true;
+        const size_t m = 449;
+        DualVectors dv(m, 123);
+
+        cltj::hashing::rank_support_glgh<> rank_glgh(&dv.Gl, &dv.Gh);
+        cltj::hashing::rank_support_packed_glgh<> rank_packed(&dv.G);
+
+        ok = rank_packed.size_in_bytes() == rank_glgh.size_in_bytes();
+        for (size_t v = 0; ok && v <= m; ++v) {
+            if (rank_packed.rank(v) != rank_glgh.rank(v)) {
+                ok = false;
+            }
+        }
+
+        if (!ok)
+            ++failures;
+        std::cout << "  boundary near superblock (m=" << m << "): " << (ok ? "OK" : "FAIL") << "\n";
+    }
+
     // Serialize/load round-trip: a loaded rank must answer like the original.
     {
         bool ok = true;


### PR DESCRIPTION
## What changed

- `ModPolicy`: third template parameter on `MPHF`, selecting the hash modulo implementation. `NativeMod` (default, `v % p`) or `FastMod` (Lemire's `fastmod_u64` with precomputed per-prime magic).
- `PackedGlGhStorage`: new storage strategy that packs G into a single `int_vector<2>` (one memory access per lookup) instead of the two parallel bitvectors of `GlGhStorage` (two memory accesses per lookup). Same 2.81 bits/key. Ships with its own `rank_support_packed_glgh`, which started as a copy of sdsl's `rank_support_v` and was adapted in two places: (1) occupancy is extracted from packed 2-bit lanes via bitwise SWAR instead of `~(gl & gh)`, and (2) since a 64-bit word holds 32 vertices instead of 64, a logical block of 64 vertices spans two consecutive physical words, with a branch in the partial count to split at the 32-vertex boundary. The superblock/block metadata layout is unchanged, so the rank overhead stays identical to GlGh.
- Tests: `test-modpolicy` (FastMod equivalence), `test-packed-glgh` (storage equivalence), `test-packed-glgh-mphf` (MPHF with NoKey and QuotientKey, round-trip), and `test-rank-support-packed-glgh` (rank equivalence against GlGh's rank).
- Micro-bench: `bench-fastmod-micro` to gate whether `fastmod_u64` beats native `%` in compute-isolated (_hopefully_) conditions.

## Why

After integrating GlGh into the MPHF-Experiments benchmark (LTJ-23), we saw the query gap vs cmph-BDZ: ~100 ns vs ~22 ns at 100M keys. This PR adds two opt-in features that attempt to improve GlGh's query. Both are disabled by default because measurements did not justify enabling either:

- `FastMod`: replaces the native `%` with Lemire's `fastmod_u64`. GlGh's hash uses three modular multiplications per query, and since the quotienting scheme prevents hash tricks like Jenkins, this was a natural thing to try. On the real query it is slower (~11% at 10M, ~26% at 100M).
- `PackedGlGhStorage`: packs GlGh's two parallel bitvectors into a single `int_vector<2>` (same 2.81 bits/key, one memory access per lookup instead of two). The idea came from the gap growing with N -- from 13 ns at 10M to 78 ns at 100M -- which pointed at a cache/memory issue rather than compute. BDZ uses a single packed array, so this was worth trying. It wins ~10% at 100M but loses ~10% at 10M. The crossover is around 65M keys. Below that, the extra work in the rank costs more than the memory win. A future per-node switch could use Packed for the largest nodes (3 nodes >= 50M keys hold 24% of the keys in Wikidata), but that is out of scope here.

## Out of scope

- Neither mechanism is enabled in `compact_metatrie_hash`; it keeps `GlGhStorage` + `NativeMod`. Choosing Packed per-node on the largest nodes is left as a follow-up/idea, didn't make a real trie-query measurement yet.
- So, CLTJ remains unchanged.
